### PR TITLE
feat: bound viewmodel fields

### DIFF
--- a/django-testbed/frontend/src/views/UserListView.js
+++ b/django-testbed/frontend/src/views/UserListView.js
@@ -47,20 +47,14 @@ export default function UserListView() {
                     {records.map(record => (
                         <tr key={record._pk}>
                             <td>
-                                <FieldFormatter
-                                    field={User.fields.first_name}
-                                    value={record.first_name}
-                                />
-                                <FieldFormatter
-                                    field={User.fields.last_name}
-                                    value={record.last_name}
-                                />
+                                <FieldFormatter field={record._f.first_name} />
+                                <FieldFormatter field={record._f.last_name} />
                             </td>
                             <td>
-                                <FieldFormatter field={User.fields.email} value={record.email} />
+                                <FieldFormatter field={record._f.email} />
                             </td>
                             <td>
-                                <FieldFormatter field={User.fields.region} value={record.region} />
+                                <FieldFormatter field={record._f.region} />
                             </td>
                             <td>
                                 <button onClick={() => selectId(record._pk)}>Edit</button>

--- a/js-packages/@prestojs/ui/src/FieldFormatter.tsx
+++ b/js-packages/@prestojs/ui/src/FieldFormatter.tsx
@@ -12,11 +12,16 @@ export default function FieldFormatter<FieldValue>({
     ...rest
 }: {
     field: Field<FieldValue>;
+    value?: any;
     [rest: string]: any;
 }): React.ReactElement {
     const { getFormatterForField } = useUi();
 
     const Formatter = getFormatterForField(field) as React.ComponentType<any>;
+
+    if (field.isBound && !('value' in rest)) {
+        rest.value = field.value;
+    }
 
     if (Array.isArray(Formatter)) {
         const [ActualFormatter, props] = Formatter;

--- a/js-packages/@prestojs/viewmodel/src/__tests__/ViewModel.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/__tests__/ViewModel.test.ts
@@ -530,3 +530,24 @@ describe('env tests', () => {
         });
     });
 });
+
+test('should bind fields to _f', () => {
+    class A extends ViewModel {
+        static _fields = {
+            id: new Field({ label: 'Id' }),
+            name: new Field({ label: 'Name' }),
+            email: new Field({ label: 'Email' }),
+        };
+    }
+
+    const record1 = new A({
+        id: 1,
+        name: 'bob',
+        email: 'a@b',
+    });
+
+    expect(record1._f.name).toBeInstanceOf(Field);
+    expect(record1._f.name.value).toBe('bob');
+    expect(record1._f.email.value).toBe('a@b');
+    expect(record1._f.id.value).toBe(1);
+});

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -216,4 +216,22 @@ export default class Field<T> {
     public clone(): Field<T> {
         return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     }
+
+    /**
+     * Returns true if field is bound to a ViewModel instance. When a field is bound to a instance
+     * the value for that field is accessible on the 'value' property.
+     */
+    public get isBound(): boolean {
+        // See ViewModel._f for implementation of when this will be true
+        return false;
+    }
+
+    /**
+     * When `isBound` is true this will return the current value of this field on the bound ViewModel.
+     * Otherwise will always be undefined.
+     */
+    public get value(): void {
+        console.warn('Accessed value on unbound field - this will never return a value');
+        return undefined;
+    }
 }


### PR DESCRIPTION
affects: @prestojs/ui, @prestojs/viewmodel

See https://gitlab.internal.alliancesoftware.com.au/alliance/presto/issues/22

There was some discussion as to whether we actually want this to be part of the API... so we can discard this if we think it's a bad idea.

----

This introduces concept of bound ViewModel fields which give you access
to a field via a record instance with the addition of the 'value' and
'isBound' properties. This makes it more concise when both the value and
field are required:

```js
<FieldFormatter field={User.fields.email} value={user.email} />
```

becomes

```js
<FieldFormatter field={user._f.email} />
```