### PR TITLE
feature: add replaceStateControllers

### DIFF
--- a/js-packages/@prestojs/rest/src/InferredPaginator.ts
+++ b/js-packages/@prestojs/rest/src/InferredPaginator.ts
@@ -120,6 +120,9 @@ export default class InferredPaginator implements PaginatorInterface {
     setCurrentState: (nextValue: PaginatorState) => void;
     setInternalState: (set: (internalState: Record<string, any>) => Record<any, string>) => void;
 
+    /**
+     * @see documentation for `replaceStateControllers` for what `currentStatePair` and `internalStatePair` are
+     */
     constructor(currentStatePair, internalStatePair) {
         if ((currentStatePair || internalStatePair) && !(currentStatePair && internalStatePair)) {
             throw new Error(
@@ -131,6 +134,9 @@ export default class InferredPaginator implements PaginatorInterface {
         }
     }
 
+    /**
+     * @see `Paginator.replaceStateControllers`
+     */
     replaceStateControllers(
         [currentState, setCurrentState],
         [internalState, setInternalState]

--- a/js-packages/@prestojs/rest/src/Paginator.ts
+++ b/js-packages/@prestojs/rest/src/Paginator.ts
@@ -17,6 +17,9 @@ export default class Paginator<State, InternalState> implements PaginatorInterfa
     setCurrentState: (set: State) => void;
     setInternalState: (set: InternalState) => void;
 
+    /**
+     * @see documentation for `replaceStateControllers` for what `currentStatePair` and `internalStatePair` are
+     */
     constructor(currentStatePair = null, internalStatePair = null) {
         if ((currentStatePair || internalStatePair) && !(currentStatePair && internalStatePair)) {
             throw new Error(
@@ -45,15 +48,17 @@ export default class Paginator<State, InternalState> implements PaginatorInterfa
      * This design is a compromise between allowing a clear interface for how paginators should
      * be defined and allowing the state to be managed externally (eg. using React state).
      *
-     * @param currentState
-     * @param setCurrentState
-     * @param internalState
-     * @param setInternalState
+     * @param currentStatePair The state object and setter (eg. from `useState`) that is used to store
+     * and transition pagination state. Using this you can do things like easily store state in the URL
+     * (eg. using `useUrlQueryState`) or other data sources.
+     * @param internalStatePair The state object and setter that is used for internal state. Internal state
+     * is stored separately as it does not need to be restored (eg. if you refresh the page). It is used
+     * to store things like the total number of results or the current cursor. Passing `useState` here is
+     * fine.
      */
-    replaceStateControllers(
-        [currentState, setCurrentState],
-        [internalState, setInternalState]
-    ): void {
+    replaceStateControllers(currentStatePair, internalStatePair): void {
+        const [currentState, setCurrentState] = currentStatePair;
+        const [internalState, setInternalState] = internalStatePair;
         this.currentState = currentState || {};
         this.setCurrentState = setCurrentState;
         this.internalState = internalState || {};

--- a/js-packages/@prestojs/rest/src/Paginator.ts
+++ b/js-packages/@prestojs/rest/src/Paginator.ts
@@ -17,13 +17,28 @@ export default class Paginator<State, InternalState> implements PaginatorInterfa
     setCurrentState: (set: State) => void;
     setInternalState: (set: InternalState) => void;
 
+    constructor(currentStatePair = null, internalStatePair = null) {
+        if ((currentStatePair || internalStatePair) && !(currentStatePair && internalStatePair)) {
+            throw new Error(
+                'If one of `currentStatePair` and `internalStatePair` are specified both must be'
+            );
+        }
+        if (currentStatePair && internalStatePair) {
+            this.replaceStateControllers(currentStatePair, internalStatePair);
+        }
+    }
+
     /**
-     * Paginator received 2 tuples of a state and state setter pair. This is expected to
+     * Paginator receives 2 tuples of a state and state setter pair. This is expected to
      * match the same interface as `useState` in React. The following is a valid simple usage:
      *
      * ```js
-     * new Paginator(useState(), useState());
+     * const paginator = new Paginator(useState(), useState());
      * ```
+     *
+     * Note that we can also pass the state controllers in via `replaceStateControllers` rather
+     * than in the constructor. This is so we can memoize the `Paginator` instance which is desirable
+     * when using the paginator as a dependency to React hooks.
      *
      * As state is passed in and managed external to the class be aware that any data stored
      * on the class instance will be lost unless written with `setCurrentState` or `setInternalState`.
@@ -35,7 +50,10 @@ export default class Paginator<State, InternalState> implements PaginatorInterfa
      * @param internalState
      * @param setInternalState
      */
-    constructor([currentState, setCurrentState], [internalState, setInternalState]) {
+    replaceStateControllers(
+        [currentState, setCurrentState],
+        [internalState, setInternalState]
+    ): void {
         this.currentState = currentState || {};
         this.setCurrentState = setCurrentState;
         this.internalState = internalState || {};

--- a/js-packages/@prestojs/rest/src/__tests__/CursorPaginator.test.ts
+++ b/js-packages/@prestojs/rest/src/__tests__/CursorPaginator.test.ts
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import CursorPaginator from '../CursorPaginator';
 
 function useTestHook(initialState = {}): CursorPaginator {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
     return new CursorPaginator(useState(initialState), useState());
 }
 

--- a/js-packages/@prestojs/rest/src/__tests__/LimitOffsetPaginator.test.ts
+++ b/js-packages/@prestojs/rest/src/__tests__/LimitOffsetPaginator.test.ts
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import LimitOffsetPaginator from '../LimitOffsetPaginator';
 
 function useTestHook(initialState = {}): LimitOffsetPaginator {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
     return new LimitOffsetPaginator(useState(initialState), useState());
 }
 

--- a/js-packages/@prestojs/rest/src/__tests__/PageNumberPaginator.test.ts
+++ b/js-packages/@prestojs/rest/src/__tests__/PageNumberPaginator.test.ts
@@ -3,6 +3,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import PageNumberPaginator from '../PageNumberPaginator';
 
 function useTestHook(initialState = {}): PageNumberPaginator {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
     return new PageNumberPaginator(useState(initialState), useState());
 }
 

--- a/js-packages/@prestojs/rest/src/usePaginator.ts
+++ b/js-packages/@prestojs/rest/src/usePaginator.ts
@@ -36,16 +36,15 @@ export default function usePaginator<T extends PaginatorInterface, PaginatorStat
                 ? paginatorClassOrEndpoint.getPaginatorClass()
                 : paginatorClassOrEndpoint;
     }
-    // It's expected that the paginator will be recreated regularly (ie. after every
-    // state change) but memo it so that outside of that it is cached.
-    return useMemo(
-        () =>
-            paginatorClass
-                ? new paginatorClass(
-                      [currentState, setCurrentState],
-                      [internalState, setInternalState]
-                  )
-                : null,
-        [currentState, internalState, paginatorClass, setCurrentState]
+
+    // Only recreate the paginator class instance when necessary (eg. if the type changes)
+    const paginatorInstance = useMemo(() => (paginatorClass ? new paginatorClass() : null), [
+        paginatorClass,
+    ]);
+    paginatorInstance.replaceStateControllers(
+        [currentState, setCurrentState],
+        [internalState, setInternalState]
     );
+
+    return paginatorInstance;
 }


### PR DESCRIPTION
This change is so we can maintain the identify of the paginator instance and just switch out the state as required.

This is desirable so can write hooks that use the paginator as a dependency without it changing every render