### PR TITLE
fix: add fieldClassName static prop to fields

### DIFF
--- a/doc-site/getWidgetForField.js
+++ b/doc-site/getWidgetForField.js
@@ -57,8 +57,9 @@ const choicesMapping = new Map([
 export default function getWidgetForField(field) {
     // Couldn't work out what to type this as so field.constructor was accepted
     const widget = field.choices
-        ? choicesMapping.get(field.constructor.name) || mapping.get(field.constructor.name)
-        : mapping.get(field.constructor.name);
+        ? choicesMapping.get(field.constructor.fieldClassName) ||
+          mapping.get(field.constructor.fieldClassName)
+        : mapping.get(field.constructor.fieldClassName);
 
     const getReturnWithChoices = (w, f) => {
         if (f.choices) {
@@ -80,8 +81,8 @@ export default function getWidgetForField(field) {
     let f = Object.getPrototypeOf(field.constructor);
     do {
         const widgetF = field.choices
-            ? choicesMapping.get(f.name) || mapping.get(f.name)
-            : mapping.get(f.name);
+            ? choicesMapping.get(f.fieldClassName) || mapping.get(f.fieldClassName)
+            : mapping.get(f.fieldClassName);
         if (widgetF) {
             return getReturnWithChoices(widgetF, field);
         }

--- a/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
+++ b/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
@@ -41,14 +41,17 @@ const choicesMapping = new Map<string, FieldWidgetType<any, any>>([
  * Returns the default widget for any given Field.
  *
  * Depending on Field, this will return either a FieldWidget component directly, or [FieldWidget, props] where props is the default props that would be applied to said widget.
+ *
+ * @extract-docs
  */
 export default function getWidgetForField<FieldValue, T extends HTMLElement>(
     field: Field<FieldValue>
 ): FieldWidgetType<FieldValue, T> | [FieldWidgetType<FieldValue, T>, object] | null {
+    const { fieldClassName } = Object.getPrototypeOf(field).constructor;
     // Couldn't work out what to type this as so field.constructor was accepted
     const widget: FieldWidgetType<any, any> | null | undefined = field.choices
-        ? choicesMapping.get(field.constructor.name) || mapping.get(field.constructor.name)
-        : mapping.get(field.constructor.name);
+        ? choicesMapping.get(fieldClassName) || mapping.get(fieldClassName)
+        : mapping.get(fieldClassName);
 
     const getReturnWithChoices = (
         w,
@@ -73,8 +76,8 @@ export default function getWidgetForField<FieldValue, T extends HTMLElement>(
     let f = Object.getPrototypeOf(field.constructor);
     do {
         const widgetF: FieldWidgetType<any, any> | null | undefined = field.choices
-            ? choicesMapping.get(f.name) || mapping.get(f.name)
-            : mapping.get(f.name);
+            ? choicesMapping.get(f.fieldClassName) || mapping.get(f.fieldClassName)
+            : mapping.get(f.fieldClassName);
         if (widgetF) {
             return getReturnWithChoices(widgetF, field);
         }

--- a/js-packages/@prestojs/viewmodel/src/fields/BooleanField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/BooleanField.ts
@@ -11,6 +11,7 @@ import NullableBooleanField from './NullableBooleanField';
  * @menu-group Fields
  */
 export default class BooleanField extends NullableBooleanField {
+    static fieldClassName = 'BooleanField';
     parse(value: any): boolean {
         return !!value;
     }

--- a/js-packages/@prestojs/viewmodel/src/fields/CharField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/CharField.ts
@@ -14,6 +14,7 @@ type CharFieldProps = FieldProps<string> & { maxLength?: number };
  * @menu-group Fields
  */
 export default class CharField extends Field<string> {
+    static fieldClassName = 'CharField';
     public maxLength?: number;
 
     constructor(values: CharFieldProps = {}) {

--- a/js-packages/@prestojs/viewmodel/src/fields/CurrencyField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/CurrencyField.ts
@@ -8,4 +8,6 @@ import DecimalField from './DecimalField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class CurrencyField extends DecimalField {}
+export default class CurrencyField extends DecimalField {
+    static fieldClassName = 'CurrencyField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
@@ -14,6 +14,7 @@ import Field from './Field';
  * @menu-group Fields
  */
 export default class DateField extends Field<Date, string | Date> {
+    static fieldClassName = 'DateField';
     parse(value: any): Date | null {
         if (Number.isNaN(Date.parse(value))) {
             return null;

--- a/js-packages/@prestojs/viewmodel/src/fields/DateRangeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateRangeField.ts
@@ -4,4 +4,6 @@ import RangeField from './RangeField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class DateRangeField extends RangeField<Date> {}
+export default class DateRangeField extends RangeField<Date> {
+    static fieldClassName = 'DateRangeField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
@@ -12,6 +12,7 @@ import Field from './Field';
  * @menu-group Fields
  */
 export default class DateTimeField extends Field<Date, string | Date> {
+    static fieldClassName = 'DateTimeField';
     parse(value: any): Date | null {
         if (Number.isNaN(Date.parse(value))) {
             return null;

--- a/js-packages/@prestojs/viewmodel/src/fields/DateTimeRangeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateTimeRangeField.ts
@@ -4,4 +4,6 @@ import RangeField from './RangeField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class DateTimeRangeField extends RangeField<Date> {}
+export default class DateTimeRangeField extends RangeField<Date> {
+    static fieldClassName = 'DateTimeRangeField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/DecimalField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DecimalField.ts
@@ -13,6 +13,7 @@ import NumberField from './NumberField';
  * @menu-group Fields
  */
 export default class DecimalField extends NumberField<string> {
+    static fieldClassName = 'DecimalField';
     public decimalPlaces?: number;
 
     constructor(values) {

--- a/js-packages/@prestojs/viewmodel/src/fields/DurationField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DurationField.ts
@@ -10,4 +10,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class DurationField extends CharField {}
+export default class DurationField extends CharField {
+    static fieldClassName = 'DurationField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/EmailField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/EmailField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class EmailField extends CharField {}
+export default class EmailField extends CharField {
+    static fieldClassName = 'EmailField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -78,6 +78,18 @@ export default class Field<T, ParsableType extends any = T> {
         }
         return this._name;
     }
+
+    /**
+     * Field class name
+     *
+     * This exists so things like [getWidgetForField](doc:getWidgetForField) can select a widget for
+     * a field without needing to import all fields up front.
+     *
+     * For custom fields this isn't required unless your implementation of `getWidgetForField` wants
+     * to do avoid importing the field up front.
+     */
+    static fieldClassName: string | null = null;
+
     /** Is this field required when saving a record? */
     public required: boolean;
     /**

--- a/js-packages/@prestojs/viewmodel/src/fields/FileField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/FileField.ts
@@ -8,4 +8,6 @@ import Field from './Field';
  * @extract-docs
  * @menu-group Fields
  */
-export default class FileField extends Field<File> {}
+export default class FileField extends Field<File> {
+    static fieldClassName = 'FileField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/FloatField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/FloatField.ts
@@ -11,6 +11,7 @@ import NumberField from './NumberField';
  * @menu-group Fields
  */
 export default class FloatField extends NumberField<number> {
+    static fieldClassName = 'FloatField';
     parse(value: any): number | null {
         // Don't force empty string, null or undefined to a number (which would be 0) -
         // force them both to be null to represent no value set.

--- a/js-packages/@prestojs/viewmodel/src/fields/FloatRangeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/FloatRangeField.ts
@@ -4,4 +4,6 @@ import RangeField from './RangeField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class FloatRangeField extends RangeField<number> {}
+export default class FloatRangeField extends RangeField<number> {
+    static fieldClassName = 'FloatRangeField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/IPAddressField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/IPAddressField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class IPAddressField extends CharField {}
+export default class IPAddressField extends CharField {
+    static fieldClassName = 'IPAddressField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/ImageField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/ImageField.ts
@@ -8,4 +8,6 @@ import FileField from './FileField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class ImageField extends FileField {}
+export default class ImageField extends FileField {
+    static fieldClassName = 'ImageField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/IntegerField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/IntegerField.ts
@@ -5,6 +5,7 @@ import NumberField from './NumberField';
  * @menu-group Fields
  */
 export default class IntegerField extends NumberField<number> {
+    static fieldClassName = 'IntegerField';
     parse(value: any): number | null {
         if (value === '' || value == null) {
             return null;

--- a/js-packages/@prestojs/viewmodel/src/fields/IntegerRangeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/IntegerRangeField.ts
@@ -4,4 +4,6 @@ import RangeField from './RangeField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class IntegerRangeField extends RangeField<number> {}
+export default class IntegerRangeField extends RangeField<number> {
+    static fieldClassName = 'IntegerRangeField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/JsonField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/JsonField.ts
@@ -11,6 +11,7 @@ export type JSON<T> = string & { ' __JSON': T };
  * @menu-group Fields
  */
 export default class JsonField<T> extends CharField {
+    static fieldClassName = 'JsonField';
     parse<T>(json: JSON<T>): T {
         try {
             return JSON.parse(json as string) as any;

--- a/js-packages/@prestojs/viewmodel/src/fields/NullableBooleanField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/NullableBooleanField.ts
@@ -11,6 +11,7 @@ import Field from './Field';
  * @menu-group Fields
  */
 export default class NullableBooleanField extends Field<boolean> {
+    static fieldClassName = 'NullableBooleanField';
     parse(value: any): boolean | null {
         if (value === undefined || value === null) {
             return null;

--- a/js-packages/@prestojs/viewmodel/src/fields/NumberField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/NumberField.ts
@@ -17,6 +17,7 @@ type NumberFieldProps<T> = FieldProps<T> & {
  * @menu-group Fields
  */
 export default class NumberField<T = string | number> extends Field<T> {
+    static fieldClassName = 'NumberField';
     public minValue?: number;
     public maxValue?: number;
 

--- a/js-packages/@prestojs/viewmodel/src/fields/RangeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/RangeField.ts
@@ -18,6 +18,7 @@ interface Boundary<T> extends FieldProps<T> {
  * @menu-group Fields
  */
 export default class RangeField<T> extends Field<T> {
+    static fieldClassName = 'RangeField';
     public lowerBound: T | null | undefined;
     public upperBound: T | null | undefined;
     public separator: string;

--- a/js-packages/@prestojs/viewmodel/src/fields/SlugField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/SlugField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class SlugField extends CharField {}
+export default class SlugField extends CharField {
+    static fieldClassName = 'SlugField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/TextField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/TextField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class TextField extends CharField {}
+export default class TextField extends CharField {
+    static fieldClassName = 'TextField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/TimeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/TimeField.ts
@@ -8,4 +8,6 @@ import Field from './Field';
  * @extract-docs
  * @menu-group Fields
  */
-export default class TimeField extends Field<string> {}
+export default class TimeField extends Field<string> {
+    static fieldClassName = 'TimeField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/URLField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/URLField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class URLField extends CharField {}
+export default class URLField extends CharField {
+    static fieldClassName = 'URLField';
+}

--- a/js-packages/@prestojs/viewmodel/src/fields/UUIDField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/UUIDField.ts
@@ -4,4 +4,6 @@ import CharField from './CharField';
  * @extract-docs
  * @menu-group Fields
  */
-export default class UUIDField extends CharField {}
+export default class UUIDField extends CharField {
+    static fieldClassName = 'UUIDField';
+}


### PR DESCRIPTION
This allows getWidgetForField to read this to determine what widget to return
for a field without needing to import the field class itself to use instanceof.
Resolves issues with using constructor.name which doesn't work with minified
builds.

Resolves #55