### PR TITLE
fix: throw on invalid field access

### DIFF
--- a/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
@@ -890,6 +890,23 @@ export default function viewModelFactory<T extends FieldsMapping>(
             ];
             boundFields.set(modelClass as ViewModelConstructor<FinalFields>, f);
         }
+        if (isDev() && typeof Proxy != 'undefined') {
+            // In dev throw an error if invalid field is accessed
+            return [
+                new Proxy(f[0], {
+                    get(target, prop: string): Field<any> {
+                        if (!(prop in target)) {
+                            const validFieldNames = Object.keys(target).join(', ');
+                            throw new Error(
+                                `Attempted to access field '${prop}' but does not exist. Valid field names are: ${validFieldNames}`
+                            );
+                        }
+                        return target[prop];
+                    },
+                }),
+                f[1],
+            ];
+        }
         return f;
     }
 


### PR DESCRIPTION
Only happens in dev. Gives much more useful feedback in various
circumstances eg. if you typo field name when using form:
  <Form.Field field={User.fields.firstNam} />
without this change you'll get an error from Field about field
or children being required.