### PR TITLE
fix: ViewModelCache getAll fix

### DIFF
--- a/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
@@ -1425,13 +1425,14 @@ export default class ViewModelCache<
         fieldNames: readonly FieldNames[]
     ): PartialViewModel<ViewModelClassType, FieldNames>[] {
         const records: PartialViewModel<ViewModelClassType, FieldNames>[] = [];
-        let isSame = true;
         let index = 0;
         const key = getFieldNameCacheKey(fieldNames as readonly string[], this.viewModel);
         const lastRecords = (this._lastAllRecords.get(key) || []) as PartialViewModel<
             ViewModelClassType,
             FieldNames
         >[];
+        // Tracks if records have changed from what is stored in `lastRecords`
+        let isRecordsSame = true;
         for (const cacheValue of this.cache.values()) {
             const record = cacheValue.get(fieldNames) as PartialViewModel<
                 ViewModelClassType,
@@ -1440,12 +1441,14 @@ export default class ViewModelCache<
             if (record) {
                 records.push(record);
                 if (index > lastRecords.length - 1 || lastRecords[index] !== record) {
-                    isSame = false;
+                    isRecordsSame = false;
                 }
                 index += 1;
             }
         }
-        if (isSame) {
+        // we need to also check the size because if the last record was removed then no
+        // comparison of that record will have taken place so isRecordsSame will still be true
+        if (isRecordsSame && lastRecords.length === records.length) {
             return lastRecords;
         }
         this._lastAllRecords.set(key, records);

--- a/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelCache.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelCache.test.ts
@@ -379,6 +379,16 @@ test('should support removing records from cache', () => {
     expect(Test1.cache.get(2, ['id', 'email'])).toBeNull();
     expect(Test1.cache.get(2, ['id', 'firstName'])).toBeNull();
     expect(Test1.cache.get(2, ['id', 'lastName'])).toBeNull();
+    for (let i = 0; i < 5; i++) {
+        Test1.cache.add(new Test1({ id: i, firstName: `${i}` }));
+    }
+    expect(new Set(Test1.cache.getAll(['firstName']).map(r => r.id))).toEqual(
+        new Set([0, 1, 2, 3, 4])
+    );
+    Test1.cache.delete(4);
+    expect(new Set(Test1.cache.getAll(['firstName']).map(r => r.id))).toEqual(
+        new Set([0, 1, 2, 3])
+    );
 });
 
 test('should support removing records from cache for only specified field names', () => {


### PR DESCRIPTION
- Fix bug that meant if a record was deleted from the _end_ of a list then
  getAll would return the previous list. This was due to an optimisation
  that ensures the same array object is returned if it's the same list of
  records to be returned.