### PR TITLE
fix: endpoint method defaults

### DIFF
--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -642,13 +642,6 @@ export default class Endpoint<ReturnT = any> {
         const { urlArgs = {}, query, ...init } = paginator
             ? paginator.getRequestInit(restOptions)
             : options;
-        // Always make sure headers & method is set so middleware implementations can assume it exists
-        if (!init.headers) {
-            init.headers = new Headers();
-        }
-        if (!init.method) {
-            init.method = 'GET';
-        }
         const url = this.resolveUrl(this.urlPattern, urlArgs, query);
         try {
             const cls = Object.getPrototypeOf(this).constructor;
@@ -657,6 +650,13 @@ export default class Endpoint<ReturnT = any> {
                 this.requestInit,
                 init
             ) as EndpointRequestInit;
+            // Always make sure headers & method is set so middleware implementations can assume it exists
+            if (!requestInit.headers) {
+                requestInit.headers = new Headers();
+            }
+            if (!requestInit.method) {
+                requestInit.method = 'GET';
+            }
             const returnVal: ExecuteReturnVal<ReturnT> = {
                 url,
                 urlArgs,

--- a/js-packages/@prestojs/rest/src/__tests__/Endpoint.test.ts
+++ b/js-packages/@prestojs/rest/src/__tests__/Endpoint.test.ts
@@ -125,6 +125,25 @@ test('should support transformation function', async () => {
     expect((await action2.prepare().execute()).result).toEqual({ b: 'a', d: 'c' });
 });
 
+test('should support merging endpoint options and ezecute options', async () => {
+    fetchMock.mockResponse(request => {
+        return Promise.resolve({
+            body: request.method,
+            init: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'text/html',
+                },
+            },
+        });
+    });
+    const action1 = new Endpoint(new UrlPattern('/whatever/'), {
+        method: 'POST',
+    });
+    expect((await action1.execute()).result).toBe('POST');
+    expect((await action1.execute({ method: 'PATCH' })).result).toBe('PATCH');
+});
+
 test('should support merging global headers with action specific headers', async () => {
     fetchMock.mockResponse('');
     const expectHeadersEqual = (headers2): void => {


### PR DESCRIPTION
Fix bug that meant if you provided a method in the constructor it would
be replaced with 'GET' when execute was called (execute only respected
method if it was passed in the execute call)