### PR TITLE
ListField & ManyRelatedViewModelField

### DIFF
--- a/django-testbed/frontend/src/models/User.js
+++ b/django-testbed/frontend/src/models/User.js
@@ -98,7 +98,6 @@ export default class User extends BaseUser.augment({
     }),
     region: new IntegerField({
         label: 'region',
-        blank: false,
         helpText: 'Region Coding of the user',
         choices: [
             [1, 'Oceania'],

--- a/js-packages/@prestojs/final-form/src/__tests__/FormItem.test.tsx
+++ b/js-packages/@prestojs/final-form/src/__tests__/FormItem.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import { UiProvider } from '@prestojs/ui';
 import { NumberField, viewModelFactory } from '@prestojs/viewmodel';
+import { render } from '@testing-library/react';
+import React from 'react';
 import Form from '../Form';
 
-class User extends viewModelFactory({ age: new NumberField({ label: 'Age' }) }) {}
+class User extends viewModelFactory({ age: new NumberField({ blank: true, label: 'Age' }) }) {}
 
 function Widget({ input }): React.ReactElement {
     return <input name={input.name} placeholder={input.name} />;

--- a/js-packages/@prestojs/util/src/index.ts
+++ b/js-packages/@prestojs/util/src/index.ts
@@ -6,7 +6,7 @@ export { default as useAsyncValue } from './useAsyncValue';
 export { default as useAsyncListing } from './useAsyncListing';
 export { default as useMemoOne } from './useMemoOne';
 export { isPromise } from './misc';
-export { isDeepEqual } from './comparison';
+export { isDeepEqual, isEqual } from './comparison';
 
 export { default as usePaginator } from './pagination/usePaginator';
 export { default as InferredPaginator } from './pagination/InferredPaginator';

--- a/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelFactory.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelFactory.test.ts
@@ -3,7 +3,7 @@ import { getId, isIdentifiable } from '@prestojs/util';
 import CharField from '../fields/CharField';
 import Field from '../fields/Field';
 import NumberField from '../fields/NumberField';
-import RelatedViewModelField from '../fields/RelatedViewModelField';
+import { RelatedViewModelField } from '../fields/RelatedViewModelField';
 import viewModelFactory from '../ViewModelFactory';
 import ViewModelFactory, {
     expandRelationFieldPaths,
@@ -1100,7 +1100,7 @@ test('getField should support traversing relations', async () => {
 
     expect(() => Subscription.getField(['user', 'name', 'id'])).toThrow(
         new Error(
-            "Field 'name' (from [user, name, id]) on ViewModel 'User' is not a RelatedViewModelField"
+            "Field 'name' (from [user, name, id]) on ViewModel 'User' is not a field that extends BaseRelatedViewModelField"
         )
     );
 });

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -4,7 +4,7 @@ import { AsyncChoicesInterface } from './AsyncChoices';
 /**
  * @expand-properties
  */
-export interface FieldProps<T, SingleType = T> {
+export interface FieldProps<ValueT, SingleValueT = ValueT> {
     /**
      * Is this field allowed to be assigned a blank (null, undefined, "") value?
      *
@@ -30,7 +30,7 @@ export interface FieldProps<T, SingleType = T> {
     /**
      * Default value for this field. This can either be a function that returns a value or the value directly.
      */
-    defaultValue?: T | null | (() => Promise<T | null> | T | null);
+    defaultValue?: ValueT | null | (() => Promise<ValueT | null> | ValueT | null);
     // A field can have choices regardless of it's type.
     // eg. A CharField and IntegerField might both optionally have choices
     // TODO: Best way to handle remote choices? Should this be part of this
@@ -39,13 +39,13 @@ export interface FieldProps<T, SingleType = T> {
     /**
      * Choices for this field. Should be a mapping of value to the label for the choice.
      */
-    choices?: Map<SingleType, string> | [SingleType, string][];
+    choices?: Map<SingleValueT, string> | [SingleValueT, string][];
     /**
      * Asynchronous choices for this field.
      *
      * Only one of `asyncChoices` and `choices` should be passed.
      */
-    asyncChoices?: AsyncChoicesInterface<any, SingleType>;
+    asyncChoices?: AsyncChoicesInterface<any, SingleValueT>;
     /**
      * True if field should be considered read only (eg. excluded from forms)
      */
@@ -68,17 +68,20 @@ class UnboundFieldError<T, ParsableType, SingleType> extends Error {
  *
  * @extract-docs
  * @menu-group Fields
+ * @template ValueType The type of the value for this field.
+ * @template ParsableType The type this field knows how to parse into the ValueType
+ * @template SingleType The type of a single value for this field. This is only different from `ValueType` if `ValueType` is eg. an array type
  */
-export default class Field<T, ParsableType extends any = T, SingleType = T> {
+export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleValueT = ValueT> {
     // These are just for internal usage with typescript
     /**
      * @private
      */
-    __fieldValueType: T;
+    __fieldValueType: ValueT;
     /**
      * @private
      */
-    __parsableValueType: ParsableType;
+    __parsableValueType: ParsableValueT;
 
     private _model: ViewModelConstructor<any>;
     public set model(viewModel: ViewModelConstructor<any>) {
@@ -86,7 +89,7 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
     }
     public get model(): ViewModelConstructor<any> {
         if (!this._model) {
-            throw new UnboundFieldError<T, ParsableType, SingleType>(this);
+            throw new UnboundFieldError<ValueT, ParsableValueT, SingleValueT>(this);
         }
         return this._model;
     }
@@ -97,7 +100,7 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
     }
     public get name(): string {
         if (!this._name) {
-            throw new UnboundFieldError<T, ParsableType, SingleType>(this);
+            throw new UnboundFieldError<ValueT, ParsableValueT, SingleValueT>(this);
         }
         return this._name;
     }
@@ -136,11 +139,11 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
     // TODO: Best way to handle remote choices? Should this be part of this
     // interface, eg. make it async?
     // In djrad we had: choiceRefinementUrl
-    public choices?: Map<SingleType, string>;
+    public choices?: Map<SingleValueT, string>;
     /**
      * Async choices for this field.
      */
-    public asyncChoices?: AsyncChoicesInterface<any, SingleType>;
+    public asyncChoices?: AsyncChoicesInterface<any, SingleValueT>;
     /**
      * Indicates this field should only be read, not written. Not enforced but can be used by components to adjust their
      * output accordingly (eg. exclude it from a form or show it on a form with a read only input)
@@ -155,9 +158,9 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
     /**
      * @private
      */
-    protected _defaultValue?: T | null | (() => Promise<T | null> | T | null);
+    protected _defaultValue?: ValueT | null | (() => Promise<ValueT | null> | ValueT | null);
 
-    constructor(values: FieldProps<T, SingleType> = {}) {
+    constructor(values: FieldProps<ValueT, SingleValueT> = {}) {
         const {
             blank = false,
             blankAsNull = false,
@@ -226,7 +229,7 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      *
      * @param value
      */
-    public format(value: T): any {
+    public format(value: ValueT): any {
         return value;
     }
 
@@ -235,8 +238,8 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      * into a `Date`.
      * @param value
      */
-    public parse(value: ParsableType | null): T | null {
-        return (value as unknown) as T;
+    public parse(value: ParsableValueT | null): ValueT | null {
+        return (value as unknown) as ValueT;
     }
 
     /**
@@ -264,8 +267,8 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      *
      * @param value
      */
-    public normalize(value: ParsableType): T | null {
-        return (value as unknown) as T;
+    public normalize(value: ParsableValueT): ValueT | null {
+        return (value as unknown) as ValueT;
     }
 
     /**
@@ -273,14 +276,14 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      * a backend API
      * @param value
      */
-    toJS(value: T): string | number | null | {} {
+    toJS(value: ValueT): string | number | null | {} {
         return value;
     }
 
     /**
      * Get the default value for this field.
      */
-    get defaultValue(): Promise<T | null | undefined> | T | null | undefined {
+    get defaultValue(): Promise<ValueT | null | undefined> | ValueT | null | undefined {
         if (this._defaultValue instanceof Function) {
             return this._defaultValue();
         }
@@ -297,14 +300,14 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      *
      * This is used when determining if two records are equal (see ViewModel.isEqual)
      */
-    public isEqual(value1: T, value2: T): boolean {
+    public isEqual(value1: ValueT, value2: ValueT): boolean {
         return value1 === value2;
     }
 
     /**
      * Returns a clone of the field that should be functionally equivalent
      */
-    public clone(): Field<T> {
+    public clone(): Field<ValueT> {
         return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     }
 
@@ -321,7 +324,7 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
      * When `isBound` is true this will return the current value of this field on the bound ViewModel.
      * Otherwise will always be undefined.
      */
-    public get value(): undefined | T {
+    public get value(): undefined | ValueT {
         console.warn('Accessed value on unbound field - this will never return a value');
         return undefined;
     }
@@ -342,8 +345,8 @@ export default class Field<T, ParsableType extends any = T, SingleType = T> {
     }
 }
 
-export interface RecordBoundField<T, ParsableType extends any = T, SingleType = T>
-    extends Field<T, ParsableType, SingleType> {
-    readonly value: T;
+export interface RecordBoundField<ValueT, ParsableType extends any = ValueT, SingleValueT = ValueT>
+    extends Field<ValueT, ParsableType, SingleValueT> {
+    readonly value: ValueT;
     readonly isBound: true;
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -7,6 +7,8 @@ import { AsyncChoicesInterface } from './AsyncChoices';
 export interface FieldProps<T> {
     /**
      * Is this field allowed to be assigned a blank (null, undefined, "") value?
+     *
+     * Defaults to false
      */
     blank?: boolean;
     /**
@@ -157,7 +159,7 @@ export default class Field<T, ParsableType extends any = T> {
 
     constructor(values: FieldProps<T> = {}) {
         const {
-            blank = true,
+            blank = false,
             blankAsNull = false,
             label,
             helpText,

--- a/js-packages/@prestojs/viewmodel/src/fields/ListField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/ListField.ts
@@ -91,4 +91,22 @@ export default class ListField<T, ParsableType = T> extends Field<T[], ParsableT
 
         return value.map(v => this.childField.normalize(v) as T);
     }
+
+    public isEqual(value1: T[], value2: T[]): boolean {
+        if (value1 === value2) {
+            return true;
+        }
+        if (!value1 || !value2) {
+            return value1 === value2;
+        }
+        if (value1?.length !== value2.length) {
+            return false;
+        }
+        for (let i = 0; i < value1.length; i++) {
+            if (!this.childField.isEqual(value1[i], value2[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/RelatedViewModelField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/RelatedViewModelField.ts
@@ -72,11 +72,8 @@ export abstract class BaseRelatedViewModelField<
         return this.sourceField instanceof ListField;
     }
 
-    constructor({
-        to,
-        sourceFieldName,
-        ...fieldProps
-    }: RelatedViewModelFieldProps<T, FieldValueType>) {
+    constructor(props: RelatedViewModelFieldProps<T, FieldValueType>) {
+        const { to, sourceFieldName, ...fieldProps } = props;
         super(fieldProps);
         if (isViewModelClass(to)) {
             this._resolvedTo = to;
@@ -101,6 +98,12 @@ export abstract class BaseRelatedViewModelField<
         if (this.many && !(this instanceof ManyRelatedViewModelField)) {
             throw new Error(
                 'When `sourceFieldName` refers to a `ListField` you must use `ManyRelatedViewModelField` instead of `RelatedViewModelField`'
+            );
+        }
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        if (!this.many && this instanceof ManyRelatedViewModelField) {
+            throw new Error(
+                '`ManyRelatedViewModelField` must specify a `ListField` in `sourceFieldName`. For other field types use `RelatedViewModelField`.'
             );
         }
     }
@@ -287,6 +290,8 @@ export abstract class BaseRelatedViewModelField<
  *
  * Failure to do this will result in an error being thrown the first time it's accessed.
  *
+ * If you have multiple values use [ManyRelatedViewModelField](doc:ManyrelatedViewModelField) instead.
+ *
  * @extract-docs
  * @menu-group Fields
  */
@@ -324,6 +329,15 @@ export class RelatedViewModelField<
     }
 }
 
+/**
+ * Define a field that contains multiple records from another ViewModel
+ *
+ * This behaves the same as [RelatedViewModelField](doc:RelatedViewModelField) but `sourceFieldName`
+ * must refer to a [ListField](doc:ListField) and all values are an array instead of a single value.
+ *
+ * @extract-docs
+ * @menu-group Fields
+ */
 export class ManyRelatedViewModelField<
     T extends ViewModelConstructor<any>
 > extends BaseRelatedViewModelField<

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/ListField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/ListField.test.ts
@@ -1,0 +1,52 @@
+import Field from '../Field';
+import ListField from '../ListField';
+
+class TestField extends Field<string> {
+    parse(value): string {
+        return value.toLowerCase();
+    }
+    format(value): string {
+        return value.toUpperCase();
+    }
+    normalize(value): string {
+        return value.toString();
+    }
+}
+
+test('ListField call normalize correctly', () => {
+    const field = new ListField({ childField: new TestField() });
+    expect(field.normalize(null)).toEqual([]);
+    expect(field.normalize([])).toEqual([]);
+    expect(field.normalize([1, 2])).toEqual(['1', '2']);
+});
+
+test('ListField parse values correctly', () => {
+    const field = new ListField({ childField: new TestField() });
+    expect(field.parse(null)).toEqual([]);
+    expect(field.parse([])).toEqual([]);
+    expect(field.parse(['A', 'B'])).toEqual(['a', 'b']);
+});
+
+test('ListField formats values correctly', () => {
+    const field = new ListField({ childField: new TestField() });
+    expect(field.format([])).toEqual([]);
+    expect(field.format(['a', 'b'])).toEqual(['A', 'B']);
+});
+
+test('ListField sets defaultValue', () => {
+    const field1 = new ListField({ childField: new TestField(), blankAsNull: false });
+    expect(field1.defaultValue).toEqual([]);
+    const field2 = new ListField({ childField: new TestField(), blankAsNull: true });
+    expect(field2.defaultValue).toBe(null);
+});
+
+test('ListField supports blankAsNull', () => {
+    const field = new ListField({ childField: new TestField(), blankAsNull: true });
+    expect(field.defaultValue).toBe(null);
+    expect(field.parse(null)).toEqual(null);
+    expect(field.parse([])).toEqual(null);
+    expect(field.parse(['A', 'B'])).toEqual(['a', 'b']);
+
+    expect(field.normalize(null)).toEqual(null);
+    expect(field.normalize([])).toEqual(null);
+});

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/RelatedViewModelField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/RelatedViewModelField.test.ts
@@ -2,7 +2,8 @@
 // @ts-ignore
 import viewModelFactory, { ViewModelConstructor } from '../../ViewModelFactory';
 import Field from '../Field';
-import RelatedViewModelField from '../RelatedViewModelField';
+import ListField from '../ListField';
+import { ManyRelatedViewModelField, RelatedViewModelField } from '../RelatedViewModelField';
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -13,264 +14,530 @@ declare global {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function createTestModels(circular = false, promise = false) {
-    class Group extends viewModelFactory({
-        name: new Field<string>(),
-        ...(circular
-            ? {
-                  ownerId: new Field<number>(),
-                  owner: new RelatedViewModelField({
-                      // Type here isn't typeof User as it seemed to confuse typescript.. I guess
-                      // because of the circular reference
-                      to: promise
-                          ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
-                            (): Promise<ViewModelConstructor<any>> => Promise.resolve(User)
-                          : // eslint-disable-next-line @typescript-eslint/no-use-before-define
-                            (): ViewModelConstructor<any> => User,
-                      sourceFieldName: 'ownerId',
-                  }),
-              }
-            : {}),
-    }) {}
-    class User extends viewModelFactory({
-        name: new Field<string>(),
-        groupId: new Field<number | null>(),
-        group: new RelatedViewModelField({
-            to: promise ? (): Promise<typeof Group> => Promise.resolve(Group) : Group,
-            sourceFieldName: 'groupId',
-        }),
-    }) {}
-    class Subscription extends viewModelFactory({
-        userId: new Field<number>(),
-        user: new RelatedViewModelField<typeof User>({
-            to: promise ? (): Promise<typeof User> => Promise.resolve(User) : User,
-            sourceFieldName: 'userId',
-        }),
-    }) {}
-    return { User, Group, Subscription };
-}
+describe('RelatedViewModelField', () => {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    function createTestModels(circular = false, promise = false) {
+        class Group extends viewModelFactory({
+            name: new Field<string>(),
+            ...(circular
+                ? {
+                      ownerId: new Field<number>(),
+                      owner: new RelatedViewModelField({
+                          // Type here isn't typeof User as it seemed to confuse typescript.. I guess
+                          // because of the circular reference
+                          to: promise
+                              ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                                (): Promise<ViewModelConstructor<any>> => Promise.resolve(User)
+                              : // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                                (): ViewModelConstructor<any> => User,
+                          sourceFieldName: 'ownerId',
+                      }),
+                  }
+                : {}),
+        }) {}
+        class User extends viewModelFactory({
+            name: new Field<string>(),
+            groupId: new Field<number | null>(),
+            group: new RelatedViewModelField({
+                to: promise ? (): Promise<typeof Group> => Promise.resolve(Group) : Group,
+                sourceFieldName: 'groupId',
+            }),
+        }) {}
+        class Subscription extends viewModelFactory({
+            userId: new Field<number>(),
+            user: new RelatedViewModelField<typeof User>({
+                to: promise ? (): Promise<typeof User> => Promise.resolve(User) : User,
+                sourceFieldName: 'userId',
+            }),
+        }) {}
+        return { User, Group, Subscription };
+    }
 
-test('should validate sourceFieldName', () => {
-    const User = viewModelFactory({});
-    expect(() => {
+    test('should validate sourceFieldName', () => {
+        const User = viewModelFactory({});
+        expect(() => {
+            viewModelFactory({
+                user: new RelatedViewModelField({
+                    to: (): Promise<typeof User> => Promise.resolve(User),
+                    sourceFieldName: 'userId',
+                }),
+            }).fields;
+        }).toThrow(/'userId' does not exist on/);
+
         viewModelFactory({
+            userId: new Field<number>(),
             user: new RelatedViewModelField({
                 to: (): Promise<typeof User> => Promise.resolve(User),
                 sourceFieldName: 'userId',
             }),
-        }).fields;
-    }).toThrow(/'userId' does not exist on/);
-
-    viewModelFactory({
-        userId: new Field<number>(),
-        user: new RelatedViewModelField({
-            to: (): Promise<typeof User> => Promise.resolve(User),
-            sourceFieldName: 'userId',
-        }),
+        });
     });
-});
 
-test('creating with nested data should populate sourceFieldName', async () => {
-    const { User } = createTestModels();
-    const user = new User({
-        id: 1,
-        name: 'test',
-        group: {
+    test('creating with nested data should populate sourceFieldName', async () => {
+        const { User } = createTestModels();
+        const user = new User({
             id: 1,
-            name: 'Group 1',
-        },
+            name: 'test',
+            group: {
+                id: 1,
+                name: 'Group 1',
+            },
+        });
+        // Can we fix this? Return type is inferred from values passed in... groupId
+        // is added because 'group' exists but can't be inferred
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        expect(user.groupId).toBe(1);
+        expect(user._assignedFields).toEqual(['group', 'groupId', 'id', 'name']);
     });
-    // Can we fix this? Return type is inferred from values passed in... groupId
-    // is added because 'group' exists but can't be inferred
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    expect(user.groupId).toBe(1);
-    expect(user._assignedFields).toEqual(['group', 'groupId', 'id', 'name']);
-});
 
-test.each`
-    resolveViewModel
-    ${true}
-    ${false}
-`(
-    'should support circular references (requires resolveViewModel: $resolveViewModel)',
-    async ({ resolveViewModel }) => {
-        const { User, Group } = createTestModels(true, resolveViewModel);
-        if (resolveViewModel) {
-            await User.fields.group.resolveViewModel();
-        }
-        Group.cache.add({ id: 1, name: 'Staff', ownerId: 1 });
-        User.cache.add({ id: 1, name: 'Bob', groupId: 1 });
-        expect(
-            User.cache.get(1, ['name', ['group', 'name'], ['group', 'owner']])
-        ).toBeEqualToRecord(
-            new User({
-                id: 1,
-                name: 'Bob',
-                groupId: 1,
-                group: {
+    test.each`
+        resolveViewModel
+        ${true}
+        ${false}
+    `(
+        'should support circular references (requires resolveViewModel: $resolveViewModel)',
+        async ({ resolveViewModel }) => {
+            const { User, Group } = createTestModels(true, resolveViewModel);
+            if (resolveViewModel) {
+                await User.fields.group.resolveViewModel();
+            }
+            Group.cache.add({ id: 1, name: 'Staff', ownerId: 1 });
+            User.cache.add({ id: 1, name: 'Bob', groupId: 1 });
+            expect(
+                User.cache.get(1, ['name', ['group', 'name'], ['group', 'owner']])
+            ).toBeEqualToRecord(
+                new User({
                     id: 1,
-                    name: 'Staff',
-                    ownerId: 1,
-                    owner: {
+                    name: 'Bob',
+                    groupId: 1,
+                    group: {
                         id: 1,
-                        name: 'Bob',
-                        groupId: 1,
-                    },
-                },
-            })
-        );
-        // Another level...
-        expect(
-            User.cache.get(1, [
-                'name',
-                ['group', 'name'],
-                ['group', 'owner', 'name'],
-                ['group', 'owner', 'group'],
-            ])
-        ).toBeEqualToRecord(
-            new User({
-                id: 1,
-                name: 'Bob',
-                groupId: 1,
-                group: {
-                    id: 1,
-                    name: 'Staff',
-                    ownerId: 1,
-                    owner: {
-                        id: 1,
-                        name: 'Bob',
-                        groupId: 1,
-                        group: {
+                        name: 'Staff',
+                        ownerId: 1,
+                        owner: {
                             id: 1,
-                            name: 'Staff',
-                            ownerId: 1,
+                            name: 'Bob',
+                            groupId: 1,
                         },
                     },
-                },
-            })
-        );
-        expect(
-            User.cache.get(1, [
-                'name',
-                ['group', 'name'],
-                ['group', 'owner', 'name'],
-                ['group', 'owner', 'group', 'owner'],
-            ])
-        ).toBeEqualToRecord(
-            new User({
-                id: 1,
-                name: 'Bob',
-                groupId: 1,
-                group: {
+                })
+            );
+            // Another level...
+            expect(
+                User.cache.get(1, [
+                    'name',
+                    ['group', 'name'],
+                    ['group', 'owner', 'name'],
+                    ['group', 'owner', 'group'],
+                ])
+            ).toBeEqualToRecord(
+                new User({
                     id: 1,
-                    name: 'Staff',
-                    ownerId: 1,
-                    owner: {
+                    name: 'Bob',
+                    groupId: 1,
+                    group: {
                         id: 1,
-                        name: 'Bob',
-                        groupId: 1,
-                        group: {
+                        name: 'Staff',
+                        ownerId: 1,
+                        owner: {
                             id: 1,
-                            ownerId: 1,
-                            owner: {
+                            name: 'Bob',
+                            groupId: 1,
+                            group: {
                                 id: 1,
-                                name: 'Bob',
-                                groupId: 1,
+                                name: 'Staff',
+                                ownerId: 1,
                             },
                         },
                     },
-                },
-            })
-        );
-    }
-);
+                })
+            );
+            expect(
+                User.cache.get(1, [
+                    'name',
+                    ['group', 'name'],
+                    ['group', 'owner', 'name'],
+                    ['group', 'owner', 'group', 'owner'],
+                ])
+            ).toBeEqualToRecord(
+                new User({
+                    id: 1,
+                    name: 'Bob',
+                    groupId: 1,
+                    group: {
+                        id: 1,
+                        name: 'Staff',
+                        ownerId: 1,
+                        owner: {
+                            id: 1,
+                            name: 'Bob',
+                            groupId: 1,
+                            group: {
+                                id: 1,
+                                ownerId: 1,
+                                owner: {
+                                    id: 1,
+                                    name: 'Bob',
+                                    groupId: 1,
+                                },
+                            },
+                        },
+                    },
+                })
+            );
+        }
+    );
 
-test('toJS should traverse relations', async () => {
-    const { User } = createTestModels();
+    test('toJS should traverse relations', async () => {
+        const { User } = createTestModels();
 
-    expect(
-        new User({
+        expect(
+            new User({
+                id: 1,
+                name: 'Test',
+                groupId: null,
+            }).toJS()
+        ).toEqual({
             id: 1,
             name: 'Test',
             groupId: null,
-        }).toJS()
-    ).toEqual({
-        id: 1,
-        name: 'Test',
-        groupId: null,
-    });
+        });
 
-    expect(
-        new User({
+        expect(
+            new User({
+                id: 1,
+                name: 'Test',
+                group: {
+                    id: 2,
+                    name: 'Staff',
+                },
+            }).toJS()
+        ).toEqual({
+            id: 1,
+            name: 'Test',
+            groupId: 2,
+            group: {
+                id: 2,
+                name: 'Staff',
+            },
+        });
+    });
+    test('normalize should create nested records as instances of related model', async () => {
+        const { User, Group } = createTestModels();
+        const user1 = new User({
             id: 1,
             name: 'Test',
             group: {
                 id: 2,
                 name: 'Staff',
             },
-        }).toJS()
-    ).toEqual({
-        id: 1,
-        name: 'Test',
-        groupId: 2,
-        group: {
-            id: 2,
-            name: 'Staff',
-        },
+        });
+        expect(user1.group).toBeEqualToRecord(new Group({ id: 2, name: 'Staff' }));
+        // Should also work if instance of relation is passed in
+        const user2 = new User({
+            id: 1,
+            name: 'Test',
+            group: new Group({
+                id: 2,
+                name: 'Staff',
+            }),
+        });
+        expect(user2.group).toBeEqualToRecord(new Group({ id: 2, name: 'Staff' }));
     });
-});
-test('normalize should create nested records as instances of related model', async () => {
-    const { User, Group } = createTestModels();
-    const user1 = new User({
-        id: 1,
-        name: 'Test',
-        group: {
-            id: 2,
-            name: 'Staff',
-        },
+
+    test('should warn if related model is included but has mismatch on id', async () => {
+        const { User } = createTestModels();
+        const mockWarn = jest.spyOn(global.console, 'warn').mockImplementation(() => undefined);
+        new User({
+            id: 1,
+            name: 'Test',
+            groupId: 1,
+            group: {
+                id: 2,
+                name: 'Staff',
+            },
+        });
+        expect(mockWarn).toHaveBeenCalledWith(
+            expect.stringMatching(
+                /was created from nested object that had a different id to the source field name/
+            )
+        );
     });
-    expect(user1.group).toBeEqualToRecord(new Group({ id: 2, name: 'Staff' }));
-    // Should also work if instance of relation is passed in
-    const user2 = new User({
-        id: 1,
-        name: 'Test',
-        group: new Group({
-            id: 2,
-            name: 'Staff',
-        }),
+    test('normalize should create nested records as instances of related model', async () => {
+        expect(() => createTestModels(false, true).User.fields.group.to.fields).toThrowError(
+            /Call User.fields.group.resolveViewModel\(\) first/
+        );
+        // Should be fine
+        createTestModels(false, false).User.fields.group.to.fields;
+        const { User } = createTestModels();
+        User.fields.group.resolveViewModel();
+        User.fields.group.to.fields;
     });
-    expect(user2.group).toBeEqualToRecord(new Group({ id: 2, name: 'Staff' }));
 });
 
-test('should warn if related model is included but has mismatch on id', async () => {
-    const { User } = createTestModels();
-    const mockWarn = jest.spyOn(global.console, 'warn').mockImplementation(() => undefined);
-    new User({
-        id: 1,
-        name: 'Test',
-        groupId: 1,
-        group: {
-            id: 2,
-            name: 'Staff',
-        },
+describe('ManyRelatedViewModelField', () => {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    function createTestModels(circular = false, promise = false) {
+        class Group extends viewModelFactory({
+            name: new Field<string>(),
+            ...(circular
+                ? {
+                      ownerId: new Field<number>(),
+                      owner: new RelatedViewModelField({
+                          // Type here isn't typeof User as it seemed to confuse typescript.. I guess
+                          // because of the circular reference
+                          to: promise
+                              ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                                (): Promise<ViewModelConstructor<any>> => Promise.resolve(User)
+                              : // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                                (): ViewModelConstructor<any> => User,
+                          sourceFieldName: 'ownerId',
+                      }),
+                  }
+                : {}),
+        }) {}
+        class User extends viewModelFactory({
+            name: new Field<string>(),
+            groupIds: new ListField({ childField: new Field<number | null>() }),
+            groups: new ManyRelatedViewModelField({
+                to: promise ? (): Promise<typeof Group> => Promise.resolve(Group) : Group,
+                sourceFieldName: 'groupIds',
+            }),
+        }) {}
+        class Subscription extends viewModelFactory({
+            userId: new Field<number>(),
+            user: new RelatedViewModelField<typeof User>({
+                to: promise ? (): Promise<typeof User> => Promise.resolve(User) : User,
+                sourceFieldName: 'userId',
+            }),
+        }) {}
+        return { User, Group, Subscription };
+    }
+
+    test('creating with nested data should populate sourceFieldName', async () => {
+        const { User } = createTestModels();
+        const user = new User({
+            id: 1,
+            name: 'test',
+            groups: [
+                {
+                    id: 1,
+                    name: 'Group 1',
+                },
+                {
+                    id: 2,
+                    name: 'Group 2',
+                },
+            ],
+        });
+        expect(user.groupIds).toEqual([1, 2]);
+        expect(user._assignedFields).toEqual(['groupIds', 'groups', 'id', 'name']);
     });
-    expect(mockWarn).toHaveBeenCalledWith(
-        expect.stringMatching(
-            /was created from nested object that had a different id to the source field name/
-        )
+
+    test.each`
+        resolveViewModel
+        ${true}
+        ${false}
+    `(
+        'should support circular references (requires resolveViewModel: $resolveViewModel)',
+        async ({ resolveViewModel }) => {
+            const { User, Group } = createTestModels(true, resolveViewModel);
+            if (resolveViewModel) {
+                await User.fields.groups.resolveViewModel();
+            }
+            Group.cache.add({ id: 1, name: 'Staff', ownerId: 1 });
+            User.cache.add({ id: 1, name: 'Bob', groupIds: [1] });
+            expect(
+                User.cache.get(1, ['name', ['groups', 'name'], ['groups', 'owner']])
+            ).toBeEqualToRecord(
+                new User({
+                    id: 1,
+                    name: 'Bob',
+                    groupIds: [1],
+                    groups: [
+                        {
+                            id: 1,
+                            name: 'Staff',
+                            ownerId: 1,
+                            owner: {
+                                id: 1,
+                                name: 'Bob',
+                                groupIds: [1],
+                            },
+                        },
+                    ],
+                })
+            );
+            // Another level...
+            expect(
+                User.cache.get(1, [
+                    'name',
+                    ['groups', 'name'],
+                    ['groups', 'owner', 'name'],
+                    ['groups', 'owner', 'groups'],
+                ])
+            ).toBeEqualToRecord(
+                new User({
+                    id: 1,
+                    name: 'Bob',
+                    groupIds: [1],
+                    groups: [
+                        {
+                            id: 1,
+                            name: 'Staff',
+                            ownerId: 1,
+                            owner: {
+                                id: 1,
+                                name: 'Bob',
+                                groupIds: [1],
+                                groups: [
+                                    {
+                                        id: 1,
+                                        name: 'Staff',
+                                        ownerId: 1,
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                })
+            );
+            expect(
+                User.cache.get(1, [
+                    'name',
+                    ['groups', 'name'],
+                    ['groups', 'owner', 'name'],
+                    ['groups', 'owner', 'groups', 'owner'],
+                ])
+            ).toBeEqualToRecord(
+                new User({
+                    id: 1,
+                    name: 'Bob',
+                    groupIds: [1],
+                    groups: [
+                        {
+                            id: 1,
+                            name: 'Staff',
+                            ownerId: 1,
+                            owner: {
+                                id: 1,
+                                name: 'Bob',
+                                groupIds: [1],
+                                groups: [
+                                    {
+                                        id: 1,
+                                        ownerId: 1,
+                                        owner: {
+                                            id: 1,
+                                            name: 'Bob',
+                                            groupIds: [1],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                })
+            );
+        }
     );
-});
-test('normalize should create nested records as instances of related model', async () => {
-    expect(() => createTestModels(false, true).User.fields.group.to.fields).toThrowError(
-        /Call User.fields.group.resolveViewModel\(\) first/
-    );
-    // Should be fine
-    createTestModels(false, false).User.fields.group.to.fields;
-    const { User } = createTestModels();
-    User.fields.group.resolveViewModel();
-    User.fields.group.to.fields;
+
+    test('toJS should traverse relations', async () => {
+        const { User } = createTestModels();
+
+        expect(
+            new User({
+                id: 1,
+                name: 'Test',
+                groupIds: [],
+            }).toJS()
+        ).toEqual({
+            id: 1,
+            name: 'Test',
+            groupIds: [],
+        });
+
+        expect(
+            new User({
+                id: 1,
+                name: 'Test',
+                groups: [
+                    {
+                        id: 2,
+                        name: 'Staff',
+                    },
+                ],
+            }).toJS()
+        ).toEqual({
+            id: 1,
+            name: 'Test',
+            groupIds: [2],
+            groups: [
+                {
+                    id: 2,
+                    name: 'Staff',
+                },
+            ],
+        });
+    });
+    test('normalize should create nested records as instances of related model', async () => {
+        const { User, Group } = createTestModels();
+        const user1 = new User({
+            id: 1,
+            name: 'Test',
+            groups: [
+                {
+                    id: 2,
+                    name: 'Staff',
+                },
+            ],
+        });
+        expect(user1.groups).toBeEqualToRecord([new Group({ id: 2, name: 'Staff' })]);
+        // Should also work if instance of relation is passed in
+        const user2 = new User({
+            id: 1,
+            name: 'Test',
+            groups: [
+                new Group({
+                    id: 2,
+                    name: 'Staff',
+                }),
+            ],
+        });
+        expect(user2.groups).toBeEqualToRecord([new Group({ id: 2, name: 'Staff' })]);
+    });
+
+    test('should warn if related model is included but has mismatch on id', async () => {
+        const { User } = createTestModels();
+        const mockWarn = jest.spyOn(global.console, 'warn').mockImplementation(() => undefined);
+        new User({
+            id: 1,
+            name: 'Test',
+            groupIds: [1],
+            groups: [
+                {
+                    id: 2,
+                    name: 'Staff',
+                },
+            ],
+        });
+        expect(mockWarn).toHaveBeenCalledWith(
+            expect.stringMatching(
+                /was created from nested object that had a different id to the source field name/
+            )
+        );
+    });
+    test('normalize should create nested records as instances of related model', async () => {
+        expect(() => createTestModels(false, true).User.fields.groups.to.fields).toThrowError(
+            /Call User.fields.groups.resolveViewModel\(\) first/
+        );
+        // Should be fine
+        createTestModels(false, false).User.fields.groups.to.fields;
+        const { User } = createTestModels();
+        User.fields.groups.resolveViewModel();
+        User.fields.groups.to.fields;
+    });
 });
 
 // TODO: Is there a need to support compound fields? Would that mean sourceFieldName would have to be an array?

--- a/js-packages/@prestojs/viewmodel/src/index.ts
+++ b/js-packages/@prestojs/viewmodel/src/index.ts
@@ -29,7 +29,11 @@ export { default as URLField } from './fields/URLField';
 export { default as UUIDField } from './fields/UUIDField';
 export { default as useViewModelCache } from './useViewModelCache';
 export { default as AsyncChoices } from './fields/AsyncChoices';
-export { default as RelatedViewModelField } from './fields/RelatedViewModelField';
+export {
+    RelatedViewModelField,
+    ManyRelatedViewModelField,
+    BaseRelatedViewModelField,
+} from './fields/RelatedViewModelField';
 export { default as ListField } from './fields/ListField';
 export { default as useAsyncChoices } from './useAsyncChoices';
 

--- a/js-packages/@prestojs/viewmodel/src/index.ts
+++ b/js-packages/@prestojs/viewmodel/src/index.ts
@@ -30,6 +30,7 @@ export { default as UUIDField } from './fields/UUIDField';
 export { default as useViewModelCache } from './useViewModelCache';
 export { default as AsyncChoices } from './fields/AsyncChoices';
 export { default as RelatedViewModelField } from './fields/RelatedViewModelField';
+export { default as ListField } from './fields/ListField';
 export { default as useAsyncChoices } from './useAsyncChoices';
 
 export {


### PR DESCRIPTION
As part of doing this I've found various edge cases where the caching fails to do what you would expect in regards to listeners.

I've added failing test cases for these that are currently skipped. I spent many hours trying to resolve it but it's going to take a fair bit to get there I think... probably another rewrite of the internals of caching as it's really difficult to follow.

These issues exist with or without this branch however so think we may as well proceed with this as is. This extends the existing behaviour to support RelatedViewModelField's that have multiple values instead of a single value. 