### PR TITLE
feature: add deleteViewModel parameter to viewModelCachingMiddleware

### DIFF
--- a/js-packages/@prestojs/rest/src/__tests__/viewModelCachingMiddleware.test.ts
+++ b/js-packages/@prestojs/rest/src/__tests__/viewModelCachingMiddleware.test.ts
@@ -227,6 +227,23 @@ test('should support deletes', async () => {
     }).toThrowError(/UrlPattern includes an 'id' parameter/);
 });
 
+test('should support deleteViewModel option and delete/update with one call', async () => {
+    const { User, users, bilbo, Food, sausage } = createData();
+    User.cache.add(users);
+    Food.cache.add(sausage);
+    expect(User.cache.get(1, '*')).toEqual(bilbo);
+    const endpoint = new Endpoint(new UrlPattern('/user/:id'), {
+        middleware: [viewModelCachingMiddleware({ food: Food }, { deleteViewModel: User })],
+        method: 'DELETE',
+    });
+    mockJsonResponse({ food: { id: sausage.id, name: 'banana' } });
+    await endpoint.execute({ urlArgs: { id: 1 } });
+    expect(User.cache.get(1, '*')).toBe(null);
+    const newSausage = Food.cache.get(sausage.id, '*');
+    expect(newSausage.id).toEqual(sausage.id);
+    expect(newSausage.name).toEqual('banana');
+});
+
 test('should support custom getDeleteId', async () => {
     const { User, users, bilbo } = createData();
     User.cache.add(users);

--- a/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
@@ -103,10 +103,10 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  * ```js
  * const middleware = [viewModelCachingMiddleware(User)];
  * // Response is a single User instance:
- * const userRetrieve = new ViewModelEndpoint(new UrlPattern('/users/:id/'), { middleware });
+ * const userRetrieve = new Endpoint(new UrlPattern('/users/:id/'), { middleware });
  * // Response is an array of User instances
  * // (declaration is the same but the response handler will treat it differently)
- * const userList = new ViewModelEndpoint(new UrlPattern('/users/'), { middleware });
+ * const userList = new Endpoint(new UrlPattern('/users/'), { middleware });
  * ```
  *
  * If the response is an object mapping different models you can specify how each
@@ -152,7 +152,7 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  * ```js
  * const middleware = [viewModelCachingMiddleware(User)];
  * // Response is empty:
- * const userDelete = new ViewModelEndpoint(new UrlPattern('/users/:id/'), {
+ * const userDelete = new Endpoint(new UrlPattern('/users/:id/'), {
  *   middleware,
  *   method: "DELETE"
  * });
@@ -166,7 +166,7 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  * ```js
  * const middleware = [viewModelCachingMiddleware({"records.bookings": Booking}, {deleteViewModel: User})];
  * // Response would include the updated related bookings, with the number of diners reduced by 1
- * const updatedBookings = new ViewModelEndpoint(new UrlPattern('/users/:id/'), {
+ * const updatedBookings = new Endpoint(new UrlPattern('/users/:id/'), {
  *   middleware,
  *   method: "DELETE"
  * });
@@ -177,7 +177,7 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  *
  * @param viewModelMapping The mapping to use for caching as described above. When the request method is `DELETE` this
  * is assumed to be the model that should be removed from the cache unless you provide `options.deleteViewModel`. If
- * deleteViewModel` is provided then this value is used to cache the response of the delete call.
+ * `deleteViewModel` is provided then this value is used to cache the response of the delete call.
  * @param options
  *
  * @extract-docs

--- a/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
@@ -146,6 +146,32 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  *
  * Each record instance created is also automatically added to the cache.
  *
+ * Usually when deleting a model, the endpoint doesn't return anything. So by default if the endpoint method is DELETE
+ * you should pass the model that will be deleted on a successful response.
+ *
+ * ```js
+ * const middleware = [viewModelCachingMiddleware(User)];
+ * // Response is empty:
+ * const userDelete = new ViewModelEndpoint(new UrlPattern('/users/:id/'), {
+ *   middleware,
+ *   method: "DELETE"
+ * });
+ * ```
+ *
+ * Sometimes a deletion will cause a related model to change and you might want to return the modified model data.
+ * In order to do this you specify model to be deleted as the `deleteViewModel` and the model(s) to be updated as the
+ * `viewModelMapping`. Note that if you provide a `viewModelMapping` that isn't a single model without providing the
+ * deleteViewModel option, you will get an error.
+ *
+ * ```js
+ * const middleware = [viewModelCachingMiddleware({"records.bookings": Booking}, {deleteViewModel: User})];
+ * // Response would include the updated related bookings, with the number of diners reduced by 1
+ * const updatedBookings = new ViewModelEndpoint(new UrlPattern('/users/:id/'), {
+ *   middleware,
+ *   method: "DELETE"
+ * });
+ * ```
+ *
  * NOTE: If using with [paginationMiddleware](doc:paginationMiddleware) then this must come
  * before `paginationMiddleware`.
  *

--- a/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/viewModelCachingMiddleware.ts
@@ -149,7 +149,9 @@ defaultGetDeleteId.validateEndpoint = (endpoint: Endpoint): void => {
  * NOTE: If using with [paginationMiddleware](doc:paginationMiddleware) then this must come
  * before `paginationMiddleware`.
  *
- * @param viewModelMapping The mapping to use for caching as described above
+ * @param viewModelMapping The mapping to use for caching as described above. When the request method is `DELETE` this
+ * is assumed to be the model that should be removed from the cache unless you provide `options.deleteViewModel`. If
+ * deleteViewModel` is provided then this value is used to cache the response of the delete call.
  * @param options
  *
  * @extract-docs


### PR DESCRIPTION
Allows you to specify to modify the model to delete for a DELETE endpoint middleware