### PR TITLE
fix: viewModelCache cache.getAll triggering an error on models with compound keys

### DIFF
--- a/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
@@ -1488,7 +1488,8 @@ export default class ViewModelCache<
         >[];
         // Tracks if records have changed from what is stored in `lastRecords`
         let isRecordsSame = true;
-        for (const pk of this.cache.keys()) {
+        for (const recordCache of this.cache.values()) {
+            const pk = recordCache.recordPk;
             const record = this.get(pk, fieldNames as FieldNames[]);
             if (record) {
                 records.push(record);

--- a/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelCache.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/__tests__/ViewModelCache.test.ts
@@ -151,6 +151,10 @@ test('should validate pk(s)', () => {
     expect(() => Test2.cache.get({ id1: null }, ['name'])).toThrowError(
         'Test2 has a compound key of id1, id2. Missing value(s) for field(s) id1, id2'
     );
+
+    expect(Test2.cache.getAll(['id1', 'id2', 'name'])[0]).toBe(record2);
+    expect(Test2.cache.getAll(['name'])[0]).toBe(record2);
+
 });
 
 test('should always use primary key in cache regardless of whether specified', () => {


### PR DESCRIPTION

Test2 has a compound key of id1, id2. You must provide an object mapping these fields to their values.
When cache.getAll calls cache.get, it uses a string value for pk eg. id2⁞6id1⁞5

This was triggering the error where it checks that compound keys are an object.