### PR TITLE
fix: paginators no read stale state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix issue with `useViewModelCache` that could cause a render after unmount
 * (breaking) Removed `RequestError` from `Endpoint`. Instead `Endpoint` will now throw the error raised by `fetch` directly - either `TypeError` or `AbortError`.
+* Fix bugs with `RelatedViewModelField` and `ManyRelatedViewModelField` where things could break if value was `null` or `[]`
 
 ## [0.0.11] - 2021-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix issue with `useViewModelCache` that could cause a render after unmount
 * (breaking) Removed `RequestError` from `Endpoint`. Instead `Endpoint` will now throw the error raised by `fetch` directly - either `TypeError` or `AbortError`.
 * Fix bugs with `RelatedViewModelField` and `ManyRelatedViewModelField` where things could break if value was `null` or `[]`
+* Fix bug with `ViewModelCache` when passing a record with nested related fields to `get` or `getList` that meant it only traversed 1 level deep which meant the returned record could be different to the passed record.
 
 ## [0.0.11] - 2021-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 * (breaking) Removed `RequestError` from `Endpoint`. Instead `Endpoint` will now throw the error raised by `fetch` directly - either `TypeError` or `AbortError`.
 * Fix bugs with `RelatedViewModelField` and `ManyRelatedViewModelField` where things could break if value was `null` or `[]`
 * Fix bug with `ViewModelCache` when passing a record with nested related fields to `get` or `getList` that meant it only traversed 1 level deep which meant the returned record could be different to the passed record.
+* Fix issues with paginator where if multiple state transitions were called before the previous committed then only the last would be retained. This is fixed, eg. the following now works:
+    ```js
+    function onChange(page, pageSize) {
+        paginator.setPage(page);
+        if (pageSize) {
+            paginator.setPageSize(pageSize);
+        }
+    }
+    ``` 
 
 ## [0.0.11] - 2021-03-01
 

--- a/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
@@ -168,11 +168,11 @@ function getFieldNameCacheKey(
         } else {
             // getField guarantees that the field will be a RelatedViewModelField so we
             // don't need to check it here
-            const relatedField = viewModel.getField(path.slice(0, -1)) as BaseRelatedViewModelField<
-                any,
-                any,
-                any
-            >;
+            const relatedField = viewModel.getField(
+                // If the related field is empty (eg. ManyRelatedViewModelField with value []) then
+                // the path will only have 1 element which is the related field itself
+                path.length === 1 ? path : path.slice(0, -1)
+            ) as BaseRelatedViewModelField<any, any, any>;
             if (!relatedField.to.pkFieldNames.includes(path[path.length - 1])) {
                 flatFieldNames.add(path.join('.'));
             }

--- a/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
@@ -170,7 +170,24 @@ function getFieldNameCacheKey(
             // don't need to check it here
             const relatedField = viewModel.getField(
                 // If the related field is empty (eg. ManyRelatedViewModelField with value []) then
-                // the path will only have 1 element which is the related field itself
+                // the path will only have 1 element which is the related field itself.
+                // For instance if we receive data like
+                // {
+                //     title: 'Main Record',
+                //     foreignKeys: [{
+                //         id: 1,
+                //         name: 'Record Name',
+                //     }]
+                // }
+                // Then `fieldNames` will be ['title', ['foreignKeys', 'name']] and so we need
+                // to get rid of `name` to get the final related field. If we instead receive
+                // {
+                //     title: 'Main Record',
+                //     foreignKeys: []
+                // }
+                // the value is set (it's just empty) and the `fieldNames` will be ['title', ['foreignKeys']]
+                // and so the path is to the related field itself (because there's no subfields set because
+                // it's null)
                 path.length === 1 ? path : path.slice(0, -1)
             ) as BaseRelatedViewModelField<any, any, any>;
             if (!relatedField.to.pkFieldNames.includes(path[path.length - 1])) {
@@ -1215,7 +1232,7 @@ export default class ViewModelCache<
                     }`
                 );
             }
-            fieldNames = pk._assignedFields as FieldNames[];
+            fieldNames = getAssignedFieldsDeep(pk) as FieldNames[];
             pk = pk._key;
         }
         if (!fieldNames) {

--- a/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
@@ -918,8 +918,10 @@ export default function viewModelFactory<T extends FieldsMapping>(
                             `Related field ${name} was created from nested object that had a different id to the source field name ${sourceFieldName}: ${data[sourceFieldName]} !== ${pk}. ${pk} has been used for both.`
                         );
                     }
-                    if (assignedData[key]) {
-                        assignedData[field.sourceFieldName] = pkOrPks;
+                    // Key could be set but the value is null. In that case we want the sourceFieldName to be set to
+                    // null as well.
+                    if (key in assignedData) {
+                        assignedData[field.sourceFieldName] = pkOrPks ?? null;
                         if (!data[field.sourceFieldName]) {
                             assignedFields.push(field.sourceFieldName);
                         }

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/RelatedViewModelField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/RelatedViewModelField.test.ts
@@ -1,7 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import viewModelFactory, { ViewModelConstructor } from '../../ViewModelFactory';
+import CharField from '../CharField';
 import Field from '../Field';
+import IntegerField from '../IntegerField';
 import ListField from '../ListField';
 import { ManyRelatedViewModelField, RelatedViewModelField } from '../RelatedViewModelField';
 
@@ -538,6 +540,64 @@ describe('ManyRelatedViewModelField', () => {
         User.fields.groups.resolveViewModel();
         User.fields.groups.to.fields;
     });
+});
+
+test('should cache records with empty ManyRelatedViewModelFields', () => {
+    class Test1 extends viewModelFactory({
+        name: new CharField(),
+    }) {}
+    class Test2 extends viewModelFactory({
+        records: new ManyRelatedViewModelField({
+            to: Test1,
+            sourceFieldName: 'recordIds',
+        }),
+        recordIds: new ListField({
+            childField: new IntegerField(),
+        }),
+    }) {}
+
+    const record1 = new Test2({ id: 5, records: [{ id: 1, name: 'Test1' }] });
+    expect(new Set(record1._assignedFields)).toEqual(new Set(['id', 'records', 'recordIds']));
+    Test2.cache.add(record1);
+    expect(Test2.cache.get(5, '*')?.toJS()).toEqual({
+        id: 5,
+        records: [{ id: 1, name: 'Test1' }],
+        recordIds: [1],
+    });
+
+    const record2 = new Test2({ id: 6, records: [] });
+    expect(new Set(record1._assignedFields)).toEqual(new Set(['id', 'records', 'recordIds']));
+    Test2.cache.add(record2);
+    expect(Test2.cache.get(6, '*')?.toJS()).toEqual({ id: 6, records: [], recordIds: [] });
+});
+
+test('should cache records with empty RelatedViewModelFields', () => {
+    class Test1 extends viewModelFactory({
+        name: new CharField(),
+    }) {}
+    class Test2 extends viewModelFactory({
+        record: new RelatedViewModelField({
+            to: Test1,
+            sourceFieldName: 'recordId',
+        }),
+        recordId: new IntegerField(),
+    }) {}
+
+    const record1 = new Test2({ id: 5, record: { id: 1, name: 'Test1' } });
+    expect(new Set(record1._assignedFields)).toEqual(new Set(['id', 'record', 'recordId']));
+    Test2.cache.add(record1);
+    expect(Test2.cache.get(5, '*')?.toJS()).toEqual({
+        id: 5,
+        record: { id: 1, name: 'Test1' },
+        recordId: 1,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore TODO: Currently type doesn't allow `null`...
+    const record2 = new Test2({ id: 6, record: null });
+    expect(new Set(record2._assignedFields)).toEqual(new Set(['id', 'record', 'recordId']));
+    Test2.cache.add(record2);
+    expect(Test2.cache.get(6, '*')?.toJS()).toEqual({ id: 6, record: null, recordId: null });
 });
 
 // TODO: Is there a need to support compound fields? Would that mean sourceFieldName would have to be an array?


### PR DESCRIPTION
This resolves issues where if you had code like:

```
onChange: (page, pageSize) => {
    paginator.setPage(page);
    if (pageSize) {
        paginator.setPageSize(pageSize);
    }
},
```

then the `setPageSize` would revert the call to `setPage` resulting
in the page never changing. This was because `setPageSize` reads
the current state internally. The implementation is such that the
easiest thing to do to maintain the current API is to just write
intermediate values to `this.currentState` directly. This should be
safe as `replaceStateControllers` should be called once the
`setState` is committed which will then set `this.currentState` to
the 'official' final value.