### PR TITLE
fix: filewidget don't set readonly fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [getWidgetForField](https://prestojs.com/docs/ui-antd/getWidgetForField/#main-content) handles [ListField](https://prestojs.com/docs/viewmodel/fields/ListField/#main-content) with `asyncChoices` or `choices`. Will currently throw for other types of `ListField`.
 * Avoid passing through `meta` to widgets in `@prestojs/ui-antd`. This avoids having invalid `meta` prop set on DOM elements.
+* [FileWidget](https://prestojs.com/docs/ui-antd/widgets/FileWidget) had a bug that would break in some browsers when loading an initial value. This has been resolved.
 
 ## [0.0.15] - 2021-04-14
 

--- a/js-packages/@prestojs/ui-antd/src/__tests__/FileWidget.test.tsx
+++ b/js-packages/@prestojs/ui-antd/src/__tests__/FileWidget.test.tsx
@@ -15,25 +15,27 @@ test('useFileList should convert File objects to antd representation', async () 
     const file1 = new File([], 'test.png', { type: 'image/png' });
     rerender({ value: file1, preview: false });
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
+            percent: 0,
             type: 'image/png',
             originFileObj: file1,
-        },
+        }),
     ]);
     rerender({ value: file1, preview: true });
     await waitForNextUpdate();
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
+            percent: 0,
             thumbUrl: expect.stringContaining('data:image/png;base64'),
             type: 'image/png',
             originFileObj: file1,
-        },
+        }),
     ]);
 
     const file2 = new File([], 'test2.png', { type: 'image/png' });
@@ -41,33 +43,36 @@ test('useFileList should convert File objects to antd representation', async () 
 
     await waitForNextUpdate();
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
+            percent: 0,
             thumbUrl: expect.stringContaining('data:image/png;base64'),
             type: 'image/png',
             originFileObj: file1,
-        },
-        {
+        }),
+        expect.objectContaining({
             uid: '-2',
             name: 'test2.png',
             size: 0,
+            percent: 0,
             thumbUrl: expect.stringContaining('data:image/png;base64'),
             type: 'image/png',
             originFileObj: file2,
-        },
+        }),
     ]);
     rerender({ value: [file1], preview: true });
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
+            percent: 0,
             thumbUrl: expect.stringContaining('data:image/png;base64'),
             type: 'image/png',
             originFileObj: file1,
-        },
+        }),
     ]);
     rerender({ value: [], preview: true });
     expect(result.current.fileList).toEqual([]);
@@ -84,16 +89,17 @@ test('useFileList should convert string urls to antd representation', async () =
     const file1 = 'test1.png';
     rerender({ value: file1, preview: false });
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
+            // Also contains lastModified, lastModifiedDate
             uid: 'test1.png',
             originFileObj: expect.objectContaining({
                 uid: 'test1.png',
-                url: 'test1.png',
             }),
             name: 'test1.png',
+            percent: 0,
             size: 0,
             type: '',
-        },
+        }),
     ]);
     const contentType = 'image/png';
     fetchMock.mockResponseOnce('abc', {
@@ -125,17 +131,18 @@ test('useFileList should handle file status updates', async () => {
         { initialProps: { value: file1, preview: false } }
     );
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
+            percent: 0,
             type: 'image/png',
             originFileObj: file1,
-        },
+        }),
     ]);
     act(() => result.current.updateFileStatus(result.current.fileList[0].uid, 'uploading', 10));
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
@@ -143,11 +150,11 @@ test('useFileList should handle file status updates', async () => {
             originFileObj: file1,
             percent: 10,
             status: 'uploading',
-        },
+        }),
     ]);
     act(() => result.current.updateFileStatus(result.current.fileList[0].uid, 'done', 100));
     expect(result.current.fileList).toEqual([
-        {
+        expect.objectContaining({
             uid: '-1',
             name: 'test.png',
             size: 0,
@@ -155,6 +162,6 @@ test('useFileList should handle file status updates', async () => {
             originFileObj: file1,
             percent: 100,
             status: 'done',
-        },
+        }),
     ]);
 });


### PR DESCRIPTION
- Don't set lastModifiedDate; instead call file2Obj and let antd handle it
- Simplify manual construction of UploadFile by using file2Obj everywhere