### PR TITLE
fix: fix TimeFormatter on safari

### DIFF
--- a/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
+++ b/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
@@ -16,11 +16,11 @@ export default function TimeFormatter({
     if (!value) return null;
 
     // we use a dummy date here as the day's irrelevant for toLocaleTimeString
-    if (Number.isNaN(Date.parse(`0999-04-11 ${value}`))) {
+    if (Number.isNaN(Date.parse(`0999-04-11T${value}`))) {
         return null;
     }
 
-    const finalValue = new Date(`0999-04-11 ${value}`);
+    const finalValue = new Date(`0999-04-11T${value}`);
 
     return finalValue.toLocaleTimeString(locales, localeOptions);
 }


### PR DESCRIPTION
Safari doesn't support Date.parse(`0999-04-11 11:11`), it will return NaN

It will however support Date.parse(`0999-04-11T11:11`), so this will fix that.