### PR TITLE
fix: fix parsing on safari

### DIFF
--- a/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
+++ b/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
@@ -34,11 +34,11 @@ export default function TimeFormatter(props: TimeFormatterProps): string | null 
     if (!value) return null;
 
     // we use a dummy date here as the day's irrelevant for toLocaleTimeString
-    if (Number.isNaN(Date.parse(`0999-04-11T${value}`))) {
+    if (Number.isNaN(Date.parse(`2020-04-11T${value}`))) {
         return null;
     }
 
-    const finalValue = new Date(`0999-04-11T${value}`);
+    const finalValue = new Date(`2020-04-11T${value}`);
 
     return finalValue.toLocaleTimeString(locales, localeOptions);
 }

--- a/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
+++ b/js-packages/@prestojs/ui/src/formatters/TimeFormatter.tsx
@@ -34,11 +34,11 @@ export default function TimeFormatter(props: TimeFormatterProps): string | null 
     if (!value) return null;
 
     // we use a dummy date here as the day's irrelevant for toLocaleTimeString
-    if (Number.isNaN(Date.parse(`2020-04-11T${value}`))) {
+    if (Number.isNaN(Date.parse(`1970-01-01T${value}`))) {
         return null;
     }
 
-    const finalValue = new Date(`2020-04-11T${value}`);
+    const finalValue = new Date(`1970-01-01T${value}`);
 
     return finalValue.toLocaleTimeString(locales, localeOptions);
 }


### PR DESCRIPTION
Turns out safari also doesn't like things in the 10th century, it would change 9am to 8:43:24.