### PR TITLE
feature: add getWidgetProps, getFormatterProps to Field

### DIFF
--- a/doc-site/pages/docs/[[...slug]].tsx
+++ b/doc-site/pages/docs/[[...slug]].tsx
@@ -28,16 +28,17 @@ export async function getStaticProps(context) {
         return value;
     });
     if (Object.keys(bySourceId).length > 0) {
-        data = JSON.parse(JSON.stringify(data), (key, value) => {
+        const reviver = (key, value) => {
             if (value && typeof value === 'object' && value._rid) {
                 const r = bySourceId[value._rid];
                 if (!r) {
                     throw new Error(`Unexpected: could not find circular ref ${value._rid}`);
                 }
-                return r;
+                return JSON.parse(JSON.stringify(r), reviver);
             }
             return value;
-        });
+        };
+        data = JSON.parse(JSON.stringify(data), reviver);
     }
     return {
         props: {

--- a/doc-site/pages/examples/viewmodel/fields/BooleanField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/BooleanField/form-usage.tsx
@@ -4,6 +4,8 @@
  * This example shows the default widget that will be used in a [Form](doc:Form)
  * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
  *
+ * The default widget is [BooleanWidget](doc:BooleanWidget)
+ *
  * `final-form` expects to be told when a field is a checkbox so it knows how to
  * handle undefined values. This example demonstrates this with the [Form.Item](doc:FormItem)
  * component.
@@ -12,6 +14,7 @@
  */
 import { Form } from '@prestojs/final-form';
 import { AntdUiProvider, FormItemWrapper, FormWrapper, getWidgetForField } from '@prestojs/ui-antd';
+import { getId, hashId } from '@prestojs/util/';
 import { BooleanField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
 import { Button } from 'antd';
 import 'antd/dist/antd.min.css';

--- a/doc-site/pages/examples/viewmodel/fields/BooleanField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/BooleanField/formatter-usage.tsx
@@ -4,6 +4,12 @@
  * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
  *
  * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `BooleanField` is [BooleanFormatter](doc:BooleanFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ * option. These will be passed through to the formatter component (eg. `trueLabel` & `falseLabel` in
+ * this example).
  */
 import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
 import { BooleanField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
@@ -12,7 +18,12 @@ import React from 'react';
 class ExampleModel extends viewModelFactory(
     {
         id: new IntegerField(),
-        isActive: new BooleanField(),
+        isActive: new BooleanField({
+            formatterProps: {
+                trueLabel: '✅',
+                falseLabel: '❌',
+            },
+        }),
         receiveNewsletter: new BooleanField({
             label: 'Subscribe to newsletter',
         }),

--- a/doc-site/pages/examples/viewmodel/fields/CharField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/CharField/form-usage.tsx
@@ -4,7 +4,12 @@
  * This example shows the default widget that will be used in a [Form](doc:Form)
  * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
  *
+ * The default widget is [CharWidget](doc:CharWidget)
+ *
  * If `maxLength` is specified the widget will limit the length of entered text.
+ *
+ * Any extra widget props can be defined at the field level in the `widgetProps` option (eg.
+ * `placeholder` in this example).
  *
  * @wide
  */
@@ -22,6 +27,11 @@ class ExampleModel extends viewModelFactory(
             maxLength: 10,
             helpText: 'Enter a name in 10 characters or less',
         }),
+        notes: new CharField({
+            widgetProps: {
+                placeholder: 'Enter any extra details',
+            },
+        }),
     },
     { pkFieldName: 'id' }
 ) {}
@@ -37,6 +47,7 @@ export default function FormUsage() {
                 <div className="grid grid-cols-1 gap-4 w-full">
                     <Form onSubmit={data => console.log(data)}>
                         <Form.Item field={ExampleModel.fields.fullName} />
+                        <Form.Item field={ExampleModel.fields.notes} />
                         <Form.Item wrapperCol={{ offset: 6 }}>
                             <Button type="primary" htmlType="submit">
                                 Submit (check console)

--- a/doc-site/pages/examples/viewmodel/fields/CharField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/CharField/formatter-usage.tsx
@@ -6,6 +6,11 @@
  * This just outputs the string exactly as entered.
  *
  * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `CharField` is [CharFormatter](doc:CharFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ * option. These will be passed through to the formatter component (eg. `blankLabel` in this example).
  */
 import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
 import { CharField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
@@ -15,12 +20,13 @@ class ExampleModel extends viewModelFactory(
     {
         id: new IntegerField(),
         fullName: new CharField(),
+        address: new CharField({ formatterProps: { blankLabel: <em>Not supplied</em> } }),
     },
     { pkFieldName: 'id' }
 ) {}
 
 export default function FormUsage() {
-    const record = new ExampleModel({ id: 1, fullName: 'PrestoJS' });
+    const record = new ExampleModel({ id: 1, fullName: 'PrestoJS', address: '' });
     return (
         <React.Suspense fallback="Loading...">
             <UiProvider getFormatterForField={getFormatterForField}>
@@ -29,6 +35,10 @@ export default function FormUsage() {
                         <dt>{ExampleModel.fields.fullName.label}</dt>
                         <dd>
                             <FieldFormatter field={record._f.fullName} />
+                        </dd>
+                        <dt>{ExampleModel.fields.address.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.address} />
                         </dd>
                     </dl>
                 </div>

--- a/doc-site/pages/examples/viewmodel/fields/DateField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DateField/form-usage.tsx
@@ -4,6 +4,8 @@
  * This example shows the default widget that will be used in a [Form](doc:Form)
  * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
  *
+ * The default widget is [DateWidget](doc:DateWidget)
+ *
  * Internally the Antd widget will use a third party date object like [Moment](https://momentjs.com/)
  * or [dayjs](https://day.js.org/). To support this you must specify `datePickerComponent` in the
  * [AntdUiProvider](doc:AntdUiProvider) usage.

--- a/doc-site/pages/examples/viewmodel/fields/DateField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DateField/formatter-usage.tsx
@@ -4,6 +4,8 @@
  * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
  *
  * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `DateField` is [DateFormatter](doc:DateFormatter).
  */
 import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
 import { DateField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';

--- a/doc-site/pages/examples/viewmodel/fields/DateTimeField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DateTimeField/form-usage.tsx
@@ -4,6 +4,8 @@
  * This example shows the default widget that will be used in a [Form](doc:Form)
  * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
  *
+ * The default widget is [DateTimeWidget](doc:DateTimeWidget)
+ *
  * Internally the Antd widget will use a third party date object like [Moment](https://momentjs.com/)
  * or [dayjs](https://day.js.org/). To support this you must specify `datePickerComponent` in the
  * [AntdUiProvider](doc:AntdUiProvider) usage.

--- a/doc-site/pages/examples/viewmodel/fields/DateTimeField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DateTimeField/formatter-usage.tsx
@@ -4,17 +4,34 @@
  * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
  *
  * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `DateTimeField` is [DateTimeFormatter](doc:DateTimeFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ *  option. These will be passed through to the formatter component (eg. `locales` & `localeOptions`
+ *  in this example).
  */
 import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
-import { DateField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import { DateTimeField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
 import React from 'react';
 
 class ExampleModel extends viewModelFactory(
     {
         id: new IntegerField(),
-        activatedAt: new DateField(),
-        deactivateAt: new DateField({
+        activatedAt: new DateTimeField({
+            formatterProps: {
+                locales: ['en-AU'],
+            },
+        }),
+        deactivateAt: new DateTimeField({
             label: 'Date deactivated',
+            formatterProps: {
+                locales: ['en-AU'],
+                localeOptions: {
+                    dateStyle: 'short',
+                    timeStyle: 'short',
+                },
+            },
         }),
     },
     { pkFieldName: 'id' }
@@ -33,12 +50,12 @@ export default function FormUsage(props) {
                     <dl>
                         <dt>{ExampleModel.fields.activatedAt.label}</dt>
                         <dd>
-                            <FieldFormatter field={record._f.activatedAt} locales={['en-AU']} />
+                            <FieldFormatter field={record._f.activatedAt} />
                         </dd>
                         <dt>{ExampleModel.fields.deactivateAt.label}</dt>
                         <dd>
                             {' '}
-                            <FieldFormatter field={record._f.deactivateAt} locales={['en-AU']} />
+                            <FieldFormatter field={record._f.deactivateAt} />
                         </dd>
                     </dl>
                 </div>

--- a/js-packages/@prestojs/doc/src/components/FunctionDocumentation.tsx
+++ b/js-packages/@prestojs/doc/src/components/FunctionDocumentation.tsx
@@ -39,7 +39,7 @@ export default function FunctionDocumentation({
             </div>
             <Description description={signature.description} />
             {parameters.length > 0 && (
-                <div className="my-5">
+                <div className="my-5 overflow-x-auto">
                     <strong className="pb-3 block">Params:</strong>
                     <TypeTable dataSource={parameters} attributeHeader="Parameter" />
                 </div>

--- a/js-packages/@prestojs/doc/src/components/Type.tsx
+++ b/js-packages/@prestojs/doc/src/components/Type.tsx
@@ -64,12 +64,29 @@ function FunctionDescription({ signatures }: { signatures }) {
 
 export default function Type({ type, mode = 'FULL' }: Props) {
     if (type.typeName === 'container') {
-        const el = (
-            <TypeTable
-                dataSource={type.children}
-                title={<strong>An object with these properties:</strong>}
-            />
-        );
+        let el;
+        if (type.children.length === 0 && type.indexSignature) {
+            console.log(type.indexSignature);
+            el = (
+                <span>
+                    <span className="text-gray-400">
+                        {'{[fieldName: string]: '}
+                        <span className="text-orange-400">
+                            <Type type={type.indexSignature.type} mode="COMPACT" />
+                        </span>
+                        {' }'}
+                    </span>
+                </span>
+            );
+        } else {
+            el = (
+                <TypeTable
+                    dataSource={type.children}
+                    title={<strong>An object with these properties:</strong>}
+                    indexSignature={type.indexSignature}
+                />
+            );
+        }
         return <ExpandableDescription expandedContent={el} mode={mode} title={type.name} />;
     }
     if (type.typeName === 'intrinsic') {

--- a/js-packages/@prestojs/doc/src/components/TypeTable.tsx
+++ b/js-packages/@prestojs/doc/src/components/TypeTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { DocType, Flags, RichDescription } from '../newTypes';
+import { DocType, Flags, IndexSignatureType, RichDescription } from '../newTypes';
 import Description from './Description';
 import Table from './Table';
 import Type from './Type';
@@ -22,7 +22,7 @@ export default function TypeTable({
     attributeHeader?: React.ReactNode;
     showRequiredColumn?: boolean;
     title?: ReactNode;
-    indexSignature?: never;
+    indexSignature?: IndexSignatureType;
 }): React.ReactElement {
     const parameters: Item[] = [];
     for (const param of dataSource) {
@@ -41,6 +41,14 @@ export default function TypeTable({
         } else {
             parameters.push(param);
         }
+    }
+    if (indexSignature) {
+        parameters.push({
+            flags: {},
+            name: '...',
+            type: indexSignature.type,
+            description: indexSignature.description,
+        });
     }
     return (
         <Table
@@ -76,9 +84,6 @@ export default function TypeTable({
                         return record.flags.expandProperties ? 2 : 1;
                     },
                     render(name, prop) {
-                        if (prop === indexSignature) {
-                            return '...';
-                        }
                         if (prop.type.typeName === 'propertiesFrom') {
                             return '...';
                         }

--- a/js-packages/@prestojs/doc/src/index.ts
+++ b/js-packages/@prestojs/doc/src/index.ts
@@ -25,4 +25,5 @@ export type {
     UnknownType,
     VariableNode,
     DocExample,
+    IndexSignatureType,
 } from './newTypes';

--- a/js-packages/@prestojs/doc/src/newTypes.ts
+++ b/js-packages/@prestojs/doc/src/newTypes.ts
@@ -138,6 +138,13 @@ export interface MethodType {
     signatures: Signature[];
 }
 
+export interface IndexSignatureType {
+    typeName: 'indexSignature';
+    description?: RichDescription;
+    parameters: { name: string; type: DocType }[];
+    type: DocType;
+}
+
 export interface ContainerType {
     typeName: 'container';
     name?: string;
@@ -147,6 +154,7 @@ export interface ContainerType {
         type: DocType;
         description?: RichDescription;
     }[];
+    indexSignature?: IndexSignatureType;
 }
 
 export interface UnknownType {

--- a/js-packages/@prestojs/final-form/src/FormItem.tsx
+++ b/js-packages/@prestojs/final-form/src/FormItem.tsx
@@ -43,7 +43,11 @@ export type FormItemProps<T> = (FormItemPropsNoField | FormItemPropsWithField<T>
  * // Fill out label, help text, required indicator and the field widget component to use based
  * // on the User email field
  * <Form.Item field={User.fields.email} />
- * // The equivalent thing writing out everything explicitly:
+ * ```
+ *
+ * The equivalent thing writing out everything explicitly:
+ *
+ * ```js
  * <Form.Item
  *     required={User.fields.email.required}
  *     label={User.fields.email.label}

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -151,7 +151,7 @@ export type EndpointExecuteOptions = ExecuteInitOptions & UrlResolveOptions;
  * ```js
  * function customFetchMiddleware(next, urlConfig, requestInit, context) {
  *   return next(new SkipToResponse(
- *       return fetch('/somewhere-else/');
+ *       fetch('/somewhere-else/')
  *   ));
  * }
  * ```
@@ -570,7 +570,7 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  * ```js
  * const userDetail = new Action(new UrlPattern('/api/user/:id/'));
  * // Resolves to /api/user/1/?showAddresses=true
- * const user = await userDetail.execute({ urlArgs: { id: 1 }, query: 'showAddresses': true });
+ * const user = await userDetail.execute({ urlArgs: { id: 1 }, query: { 'showAddresses': true }});
  * ```
  *
  * You can also pass through any `fetch` options to both the constructor and calls to `execute` and `prepare`
@@ -607,7 +607,7 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  * ```js
  * import useSWR from 'swr';
  *
- * ...
+ * // ...
  *
  * // prepare the action and pass it to useSWR. useSWR will then call the second parameter (the "fetcher")
  * // which executes the prepared action.

--- a/js-packages/@prestojs/rest/src/batchMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/batchMiddleware.ts
@@ -264,7 +264,7 @@ class BatchMiddleware<BatchCallReturn, IndividualResult> {
  *     // Batch together all calls that have identical URL (including query parameters)
  *     return call.resolvedUrl;
  *   },
- *   ...
+ *   // ...
  * });
  * ```
  *

--- a/js-packages/@prestojs/routing/src/UrlPattern.ts
+++ b/js-packages/@prestojs/routing/src/UrlPattern.ts
@@ -13,7 +13,7 @@ export interface ResolveOptions {
  * Usage:
  *
  * ```js
- * const url = new UrlPattern('/users/:id/'),
+ * const url = new UrlPattern('/users/:id/');
  * url.resolve({ id: 5 });
  * // /users/5/
  * url.resolve({ id: 5 }, { query: { showAddresses: true }});

--- a/js-packages/@prestojs/ui-antd/src/AntdUiProvider.tsx
+++ b/js-packages/@prestojs/ui-antd/src/AntdUiProvider.tsx
@@ -183,7 +183,7 @@ export type AntdUiProviderProps = {
  * function getWidgetForField(field) {
  *    // Add any app specific customisations here, eg
  *    // if (field instanceof BooleanField) {
- *    //    return CustomBooleanWidget;
+ *    //    return [CustomBooleanWidget, field.getWidgetProps()];
  *    // }
  *    // Otherwise fall back to specific UI library defaults
  *    let widget;

--- a/js-packages/@prestojs/ui-antd/src/AntdUiProvider.tsx
+++ b/js-packages/@prestojs/ui-antd/src/AntdUiProvider.tsx
@@ -117,7 +117,7 @@ export const AntdUiContext = React.createContext<AntdUiConfig | null>(null);
  *     const config = useAntdUiConfig();
  *     const DatePicker = config.getDatePicker();
  *
- *     return <DatePicker {...props} >
+ *     return <DatePicker {...props} />
  * }
  * ```
  *

--- a/js-packages/@prestojs/ui-antd/src/__tests__/getWidgetForField.test.tsx
+++ b/js-packages/@prestojs/ui-antd/src/__tests__/getWidgetForField.test.tsx
@@ -68,11 +68,11 @@ import URLWidget from '../widgets/URLWidget';
 import UUIDWidget from '../widgets/UUIDWidget';
 
 test('getWidgetForField should return widget for field', async () => {
-    const UnknownWidget = getWidgetForField(new PasswordField()) as any;
+    const [UnknownWidget, props] = getWidgetForField(new PasswordField()) as any;
 
     const { getByTestId, getByText } = render(
         <React.Suspense fallback="loading...">
-            <UnknownWidget data-testid="widget" />
+            <UnknownWidget data-testid="widget" {...props} />
         </React.Suspense>
     );
 
@@ -84,11 +84,11 @@ test('getWidgetForField should return widget for field', async () => {
 test('getWidgetForField should return widget for descendant classes of same type', async () => {
     class CustomDecimal extends NumberField {}
 
-    const UnknownWidget = getWidgetForField(new CustomDecimal()) as any;
+    const [UnknownWidget, props] = getWidgetForField(new CustomDecimal()) as any;
 
     const { getByTestId, getByText } = render(
         <React.Suspense fallback="loading...">
-            <UnknownWidget data-testid="widget" />
+            <UnknownWidget data-testid="widget" {...props} />
         </React.Suspense>
     );
 

--- a/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
+++ b/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
@@ -167,9 +167,9 @@ export default function getWidgetForField<
             const finalWidget = Array.isArray(_widget) ? _widget[0] : _widget;
             const props = Array.isArray(_widget) ? _widget[1] : {};
             const finalProps = {
+                ..._field.getWidgetProps(),
                 ...props,
                 ...extraProps,
-                ..._field.getWidgetProps(),
             };
             // Only set this when necessary to avoid passing props through
             // with undefined value that may make it's way through to the DOM

--- a/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
+++ b/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts
@@ -71,8 +71,6 @@ function splitWidgetAndProps(
  * > The widget components here are loaded using [React.lazy](https://reactjs.org/docs/code-splitting.html). Your build must support
  * > this otherwise it is recommended to implement your own version (you can copy [this implementation](https://github.com/prestojs/prestojs/blob/master/js-packages/@prestojs/ui-antd/src/getWidgetForField.ts)
  * > as a starting point).
- * >
- * > If you are using [nextjs React.lazy is not supported](https://nextjs.org/docs/advanced-features/dynamic-import) - you can [switch it out for `next/dynamic`](https://github.com/prestojs/prestojs/blob/master/doc-site/getWidgetForField.js).
  *
  * ### Simple usage:
  *
@@ -148,7 +146,7 @@ export default function getWidgetForField<
         }
         if (fieldClassName === 'ListField' && !widget) {
             const [_widget, props] = splitWidgetAndProps(
-                getWidget((field as unknown as ListField<any, any>).childField)
+                getWidget((_field as unknown as ListField<any, any>).childField)
             );
             if (_widget) {
                 return [_widget, { ...props, multiple: true }];
@@ -171,6 +169,7 @@ export default function getWidgetForField<
             const finalProps = {
                 ...props,
                 ...extraProps,
+                ..._field.getWidgetProps(),
             };
             // Only set this when necessary to avoid passing props through
             // with undefined value that may make it's way through to the DOM
@@ -180,17 +179,11 @@ export default function getWidgetForField<
             if (_field.asyncChoices) {
                 finalProps.asyncChoices = _field.asyncChoices;
             }
+
             return [finalWidget, finalProps];
         } else {
-            if (
-                widget &&
-                'maxLength' in _field &&
-                (_field as typeof _field & { maxLength: number }).maxLength > 0
-            ) {
-                return [
-                    _widget,
-                    { maxLength: (_field as typeof _field & { maxLength: number }).maxLength },
-                ];
+            if (widget) {
+                return [_widget, _field.getWidgetProps()];
             }
             return _widget;
         }

--- a/js-packages/@prestojs/ui/src/UiProvider.tsx
+++ b/js-packages/@prestojs/ui/src/UiProvider.tsx
@@ -15,7 +15,7 @@ type GetWidgetForFieldWithNull = <FieldValueT, ParsableValueT, SingleValueT, T e
 
 type GetFormatterForField = <FieldValueT, ParsableValueT, SingleValueT, T extends HTMLElement>(
     field: Field<FieldValueT, ParsableValueT, SingleValueT>
-) => string | React.ComponentType<T> | [React.ComponentType<T>, Record<string, unknown>];
+) => string | React.ComponentType<T> | [React.ComponentType<T> | string, Record<string, unknown>];
 
 type GetFormatterForFieldWithNull = <
     FieldValueT,
@@ -24,7 +24,11 @@ type GetFormatterForFieldWithNull = <
     T extends HTMLElement
 >(
     field: Field<FieldValueT, ParsableValueT, SingleValueT>
-) => string | React.ComponentType<T> | [React.ComponentType<T>, Record<string, unknown>] | null;
+) =>
+    | string
+    | React.ComponentType<T>
+    | [React.ComponentType<T> | string, Record<string, unknown>]
+    | null;
 
 export interface FormItemProps {
     children: React.ReactNode;
@@ -217,12 +221,12 @@ export default function UiProvider(props: UiProviderProps): React.ReactElement {
             ):
                 | string
                 | React.ComponentType<T>
-                | [React.ComponentType<T>, Record<string, unknown>]
+                | [React.ComponentType<T> | string, Record<string, unknown>]
                 | null {
                 let formatter:
                     | string
                     | React.ComponentType<T>
-                    | [React.ComponentType<T>, Record<string, unknown>]
+                    | [React.ComponentType<T> | string, Record<string, unknown>]
                     | null = null;
                 if (getFormatterForField) {
                     formatter = getFormatterForField(field);

--- a/js-packages/@prestojs/ui/src/UiProvider.tsx
+++ b/js-packages/@prestojs/ui/src/UiProvider.tsx
@@ -77,6 +77,17 @@ export type UiProviderProps = {
      * for this field. If falsey is returned then it will fall back to a parent UiProvider (if any) or if
      * no parent UiProvider an error will be thrown.
      *
+     * This function can return a 2-tuple of the form [component, props] where props is an object of
+     * any extra props to pass through to the component. It is recommended you include `field.getWidgetProps()`, eg.
+     *
+     * ```
+     * if (field instanceof BooleanField) {
+     *    return [CustomBooleanWidget, field.getWidgetProps()];
+     * }
+     * ```
+     *
+     * This allows [Field](doc:Field) definitions to supply extra props the widget can use.
+     *
      * @param field The specific field instance for a model
      */
     getWidgetForField?: GetWidgetForFieldWithNull;
@@ -117,11 +128,11 @@ export type UiProviderProps = {
  * function getWidgetForField(field) {
  *    // Add any app specific customisations here, eg
  *    // if (field instanceof BooleanField) {
- *    //    return CustomBooleanWidget;
+ *    //    return [CustomBooleanWidget, field.getWidgetProps()];
  *    // }
  *    // Otherwise return default widget. If you would prefer an error if no explicit widget defined for
  *    // a field then don't return anything.
- *    return DefaultWidget;
+ *    return [DefaultWidget, field.getWidgetProps()];
  * }
  *
  * function getFormatterForField(field) {

--- a/js-packages/@prestojs/ui/src/getFormatterForField.ts
+++ b/js-packages/@prestojs/ui/src/getFormatterForField.ts
@@ -75,8 +75,6 @@ const choicesMapping = new Map<string, any>([
  * > The formatter components here are loaded using [React.lazy](https://reactjs.org/docs/code-splitting.html). Your build must support
  * > this otherwise it is recommended to implement your own version (you can copy [this implementation](https://github.com/prestojs/prestojs/blob/master/js-packages/@prestojs/ui/src/getFormatterForField.ts)
  * > as a starting point).
- * >
- * > If you are using [nextjs React.lazy is not supported](https://nextjs.org/docs/advanced-features/dynamic-import) - you can [switch it out for `next/dynamic`](https://github.com/prestojs/prestojs/blob/master/doc-site/getFormatterForField.js).
  *
  * @extract-docs
  */
@@ -99,11 +97,14 @@ export default function getFormatterForField<
     ): React.ComponentType<T> | [React.ComponentType<T>, Record<string, unknown>] | string => {
         if (f.choices) {
             if (Array.isArray(w)) {
-                return [w[0], { ...w[1], choices: f.choices }];
+                return [w[0], { ...w[1], choices: f.choices, ...f.getFormatterProps() }];
             } else {
-                return [w, { choices: f.choices }];
+                return [w, { choices: f.choices, ...f.getFormatterProps() }];
             }
         } else {
+            if (w) {
+                return [w, f.getFormatterProps()];
+            }
             return w;
         }
     };

--- a/js-packages/@prestojs/util/src/identifiable.ts
+++ b/js-packages/@prestojs/util/src/identifiable.ts
@@ -1,11 +1,29 @@
-type SingleId = string | number;
-type CompoundId = { [fieldName: string]: SingleId };
+/**
+ * Type representing a single ID - eg. a number or string
+ */
+export type SingleId = string | number;
+/**
+ * Type representing a compound key, eg.
+ *
+ * ```js
+ * {
+ *     groupId: 5,
+ *     userId: 10,
+ * }
+ * ```
+ */
+export type CompoundId = { [fieldName: string]: SingleId };
+
+/**
+ * Either a single id as a number or a string, or a compound id as an object
+ * indexed by field name.
+ */
 export type Id = SingleId | CompoundId;
 
 /**
  * Interface for types that we can automatically extract a unique identifier from.
  *
- * To confirm to the interface provide a `_key` property or getter.
+ * To conform to the interface provide a `_key` property or getter.
  *
  * [ViewModelFactory](doc:viewModelFactory) conforms to this so anything that expects an Identifiable
  * will accept a ViewModel.
@@ -17,12 +35,24 @@ export type Id = SingleId | CompoundId;
  * @menu-group Identifiable
  */
 export interface Identifiable {
+    /**
+     * The unique identifier for this item.
+     */
     _key: Id;
 }
 
 /**
- * Check if a value conforms to Identifiable
+ * Check if a value conforms to [Identifiable](doc:Identifiable)
  *
+ * ## Usage
+ *
+ * ```js
+ * isIdentifiable({ _key: 1 }); // true
+ * isIdentifiable(null); // false
+ * isIdentifiable({ uuid: 'abc' }); // false
+ * ```
+ *
+ * @param item The value to check whether conforms to [Identifiable](doc:Identifiable)
  * @extract-docs
  * @menu-group Identifiable
  */
@@ -34,10 +64,20 @@ export function isIdentifiable(item: any): item is Identifiable {
 }
 
 /**
- * Get the id for an object. If object doesn't implement Identifiable then `fallbackGetId`
+ * Get the id for an object. If object doesn't implement [Identifiable](doc:Identifiable] then `fallbackGetId`
  * must be provided or an error will be thrown.
+ *
+ * ## Usage
+ *
+ * ```js
+ * const items = [{ _key: 1 }, { uuid: 'abc123' }];
+ * items.map(item => getId(item, obj => obj.uuid));
+ * // [1, 'abc123']
+ * ```
+ *
  * @param item Any value to get ID for
  * @param fallbackGetId Function to return id for `item` if it doesn't implement Identifiable
+ * @returns Either a single id as a number or a string, or a compound id as an object indexed by field name.
  *
  * @extract-docs
  * @menu-group Identifiable
@@ -57,6 +97,17 @@ export function getId(item: Identifiable | any, fallbackGetId?: (item: any) => I
 /**
  * Create string representation of ID suitable for strict equality
  * checking or as a key into an object / map.
+ *
+ * ## Usage
+ *
+ * ```js
+ * hashId(5);
+ * // 5
+ * hashId({ userId: 7, groupId: 5 });
+ * // '{"groupId":5,"userId":7}'
+ * hashId({ userId: 7, groupId: 5 }) === hashId({ userId: 7, groupId: 5 });
+ * // true
+ * ```
  *
  * @extract-docs
  * @menu-group Identifiable
@@ -83,6 +134,16 @@ export function hashId(id: Id): string {
  *
  * NOTE: Doesn't compare objects for equality; only their id
  *
+ * ## Usage
+ *
+ * ```js
+ * isSameById({ _key: 1}, { _key: 1 }); // true
+ * isSameById({ _key: 1}, { uuid: 1 }, item => item.uuid); // true
+ * ```
+ *
+ * @param item1 First item to compare
+ * @param item2 Second item to compare
+ * @param fallbackGetId Function to return id for `item` if it doesn't implement Identifiable
  * @extract-docs
  * @menu-group Identifiable
  */

--- a/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelFactory.ts
@@ -1226,27 +1226,16 @@ export class InvalidFieldError extends Error {}
  *
  * ```js
  * const fields = {
- *     userId: new IntegerField({ label: 'User ID' })
+ *     userId: new IntegerField({ label: 'User ID' }),
  *     firstName: new CharField({ label: 'First Name' }),
  *     // label is optional; will be generated as 'Last name'
  *     lastName: new CharField(),
  * };
- * // Options are all optional and can be omitted entirely
+ * // You must supplier 'pkFieldName' - everything else are optional
  * const options = {
- *     // Only one of pkFieldName or getImplicitPkField can be defined.
- *     // If neither are provided a default field called 'id' will be created.
  *     pkFieldName: 'userId',
  *     // Multiple names can be specified for compound keys
- *     pkFieldName: ['organisationId', 'departmentId']
- *     // You can also specify a function to create the primary key
- *     getImplicitPkField(model, fields) {
- *          if ('EntityId' in fields) {
- *              return ['EntityId', fields.EntityId];
- *          }
- *          // Generate a name base on model, eg. `userId`
- *          const name = model.name[0].toLowerCase() + model.name.slice(1);
- *          return [`${name}Id`, new NumberField()];
- *      },
+ *     pkFieldName: ['organisationId', 'departmentId'],
  *      // Optionally can specify a baseClass for this model. When using `augment`
  *      // this is automatically set to the class being augmented.
  *      baseClass: BaseViewModel,

--- a/js-packages/@prestojs/viewmodel/src/fields/CharField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/CharField.ts
@@ -1,4 +1,4 @@
-import Field, { FieldProps } from './Field';
+import Field, { FieldProps, ViewModelFieldWidgetProps } from './Field';
 
 /**
  * @expand-properties
@@ -53,5 +53,12 @@ export default class CharField extends Field<string> {
         super(rest);
 
         this.maxLength = maxLength;
+    }
+
+    getWidgetProps(): ViewModelFieldWidgetProps & { maxLength?: number } {
+        return {
+            ...super.getWidgetProps(),
+            maxLength: this.maxLength,
+        };
     }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -92,6 +92,33 @@ export interface FieldProps<ValueT, SingleValueT = ValueT> {
      * This isn't used by anything in PrestoJS but is useful if generating rendering values from ViewModel generically.
      */
     writeOnly?: boolean;
+    /**
+     * Any arbitrary props that should be passed to widget components
+     *
+     * These props are included in [Field.getWidgetProps](doc:Field#Method-getWidgetProps) and are
+     * passed to components by [getWidgetForField](doc:getWidgetForField).
+     *
+     * It's up to the component implementations to make use of them. By default the `@prestojs/ui-antd` components
+     * should support any of the underlying `antd` component props via this option.
+     *
+     * ```
+     * new Field({ widgetProps: { placeholder: 'Enter you name' }})
+     * ```
+     */
+    widgetProps?: Record<string, any>;
+    /**
+     * Any arbitrary props that should be passed to formatter components
+     *
+     * These props are included in [Field.getFormatterProps](doc:Field#Method-getFormatterProps) and are
+     * passed to components by [getFormatterForField](doc:getFormatterForField).
+     *
+     * It's up to the component implementations to make use of them.
+     *
+     * ```
+     * new BooleanField({ formatterProps: { trueLabel: '✅', falseLabel: '❌' }})
+     * ```
+     */
+    formatterProps?: Record<string, any>;
 }
 
 class UnboundFieldError<T, ParsableType, SingleType> extends Error {
@@ -99,6 +126,30 @@ class UnboundFieldError<T, ParsableType, SingleType> extends Error {
         const msg = `Field ${field} has not been bound to it's model. Check that the fields of the associated class are defined on the static '_fields' property and not 'fields'.`;
         super(msg);
     }
+}
+
+/**
+ * Props that are exposed by a specific [Field](doc:Field) for use by widget components
+ *
+ * @expand-properties
+ */
+export interface ViewModelFieldWidgetProps {
+    /**
+     * Any props passed through to the `Field` under the `widgetProps` option.
+     */
+    [propName: string]: any;
+}
+
+/**
+ * Props that are exposed by a specific [Field](doc:Field) for use by formatter components
+ *
+ * @expand-properties
+ */
+export interface ViewModelFieldFormatterProps {
+    /**
+     * Any props passed through to the `Field` under the `widgetProps` option.
+     */
+    [propName: string]: any;
 }
 
 /**
@@ -399,6 +450,16 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
      * but can be used by components to adjust their output accordingly (eg. exclude it from a detail view on a record)
      */
     public writeOnly: boolean;
+    /**
+     * Any props for components that use this field that were passed through to the `Field`. Don't access this directly -
+     * call `getWidgetProps` instead.
+     */
+    protected widgetProps: Record<string, any>;
+    /**
+     * Any props for components that use this field that were passed through to the `Field`. Don't access this directly -
+     * call `getFormatterProps` instead.
+     */
+    protected formatterProps: Record<string, any>;
 
     /**
      * @private
@@ -416,7 +477,11 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
             asyncChoices,
             readOnly = false,
             writeOnly = false,
+            widgetProps = {},
+            formatterProps = {},
         } = options;
+        this.widgetProps = widgetProps;
+        this.formatterProps = formatterProps;
 
         if (choices && asyncChoices) {
             throw new Error("Only one of 'choices' and 'asyncChoices' should be provided");
@@ -439,6 +504,8 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
         const unknowns = Object.keys(options).filter(
             key =>
                 ![
+                    'widgetProps',
+                    'formatterProps',
                     'blank',
                     'blankAsNull',
                     'label',
@@ -639,6 +706,36 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public contributeToClass(viewModel: ViewModelConstructor<any, any>): void {
         // Do nothing by default
+    }
+
+    /**
+     * Return any props that may be used form widgets created for this field.
+     *
+     * The default implementation just returns the optional `widgetProps` [Field](doc:Field) option but
+     * specific field implementations may return additional props.
+     *
+     * [getWidgetForField](doc:getWidgetForField) will call this method in order to generate the props that
+     * should be passed to the widget.
+     */
+    public getWidgetProps(): ViewModelFieldWidgetProps {
+        return {
+            ...this.widgetProps,
+        };
+    }
+
+    /**
+     * Return any props that may be used form formatters created for this field.
+     *
+     * The default implementation just returns the optional `formatterProps` [Field](doc:Field) option but
+     * specific field implementations may return additional props.
+     *
+     * [getFormatterForField](doc:getFormatterForField) will call this method in order to generate the props that
+     * should be passed to the formatter.
+     */
+    public getFormatterProps(): ViewModelFieldFormatterProps {
+        return {
+            ...this.formatterProps,
+        };
     }
 }
 

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -101,7 +101,7 @@ export interface FieldProps<ValueT, SingleValueT = ValueT> {
      * It's up to the component implementations to make use of them. By default the `@prestojs/ui-antd` components
      * should support any of the underlying `antd` component props via this option.
      *
-     * ```
+     * ```js
      * new Field({ widgetProps: { placeholder: 'Enter you name' }})
      * ```
      */
@@ -114,7 +114,7 @@ export interface FieldProps<ValueT, SingleValueT = ValueT> {
      *
      * It's up to the component implementations to make use of them.
      *
-     * ```
+     * ```js
      * new BooleanField({ formatterProps: { trueLabel: '✅', falseLabel: '❌' }})
      * ```
      */
@@ -214,7 +214,7 @@ export interface ViewModelFieldFormatterProps {
  * class Person extends viewModelFactory({
  *     id: new Field(),
  *     age: new IntegerField(),
- * } {}
+ * }, { pkFieldName: "id" }) {}
  * const jo = new Person({ id: 1, age: "33" });
  * jo.age
  * // 33 (as a number - not a string)
@@ -303,7 +303,7 @@ export interface ViewModelFieldFormatterProps {
  * // You can pass through the array directly
  * new Field({ choices });
  * // Or a Map
- * new Field({ choices: new Map(choices) };
+ * new Field({ choices: new Map(choices) });
  * ```
  *
  * If you access the choices via the [choices property](#Properties-choices) it will always be a `Map`.
@@ -564,7 +564,7 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
      *
      * ```js
      * // This might become
-     * {
+     * value = {
      *     name: 'Sam',
      *     address: {
      *         id: 5,
@@ -572,7 +572,7 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
      *     },
      * }
      * // ...this
-     * {
+     * value = {
      *     name: 'Same',
      *     address: 5,
      * }

--- a/js-packages/@prestojs/viewmodel/src/fields/RelatedViewModelField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/RelatedViewModelField.ts
@@ -257,7 +257,7 @@ export abstract class BaseRelatedViewModelField<
  * ```js
  * Group.cache.add({ id: 1, name: 'Staff', ownerId: 1 });
  * User.cache.add({ id: 1, name: 'Bob', groupId: 1 });
- * User.cache.get(['name', 'group', ['group', 'owner'], ['group', 'owner', 'group']);
+ * User.cache.get(['name', 'group', ['group', 'owner'], ['group', 'owner', 'group']]);
  * // {
  * //   id: 1,
  * //   name: 'Bob',

--- a/js-packages/@prestojs/viewmodel/src/index.ts
+++ b/js-packages/@prestojs/viewmodel/src/index.ts
@@ -1,6 +1,6 @@
 export { default as viewModelFactory, BaseViewModel } from './ViewModelFactory';
 export { default as ViewModelCache } from './ViewModelCache';
-export { default as Field } from './fields/Field';
+export { default as Field, ViewModelFieldWidgetProps } from './fields/Field';
 
 export { default as BooleanField } from './fields/BooleanField';
 export { default as CharField } from './fields/CharField';

--- a/js-packages/@prestojs/viewmodel/src/index.ts
+++ b/js-packages/@prestojs/viewmodel/src/index.ts
@@ -1,6 +1,6 @@
 export { default as viewModelFactory, BaseViewModel } from './ViewModelFactory';
 export { default as ViewModelCache } from './ViewModelCache';
-export { default as Field, ViewModelFieldWidgetProps } from './fields/Field';
+export { default as Field } from './fields/Field';
 
 export { default as BooleanField } from './fields/BooleanField';
 export { default as CharField } from './fields/CharField';
@@ -52,7 +52,12 @@ import type {
     Choice,
     ChoicesGrouped,
 } from './fields/AsyncChoices';
-import type { FieldProps, RecordBoundField } from './fields/Field';
+import type {
+    FieldProps,
+    RecordBoundField,
+    ViewModelFieldFormatterProps,
+    ViewModelFieldWidgetProps,
+} from './fields/Field';
 import type {
     CompoundPrimaryKey,
     FieldDataMapping,
@@ -69,6 +74,8 @@ import type {
 } from './ViewModelFactory';
 
 export type {
+    ViewModelFieldWidgetProps,
+    ViewModelFieldFormatterProps,
     ViewModelInterface,
     ViewModelConstructor,
     ViewModelValues,


### PR DESCRIPTION
This provides way for component specific props to make it's way from Field definition
to widget or formatter components.

This serves to primary purposes:
1) Allow a field like CharField to pass 'maxLength' to the component without getWidgetForField
   having to know the prop exists (previous solution).
2) Make it easy for end user to pass through arbitrary props when defining the model
   rather than having to pass it at each form/formatter usage.