### PR TITLE
NumberField parse, normalize, widget props & docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+* [Field](https://prestojs.com/docs/viewmodel/fields/Field) supports `widgetProps` & `formatterProps` 
+
 ### Changed
 
 * Support for `React.StrictMode`.
   * `useAsync` will no longer prevent `setState` calls happening after component is unmounted. If you are using < React18 you can manually do this yourself
      using the `abort` method in the calling component/hook.
   * If using @prestojs/ui-antd requires antd >= 4.20
+* [IntegerField](https://prestojs.com/docs/viewmodel/fields/IntegerField) & [FloatField](https://prestojs.com/docs/viewmodel/fields/FloatField) now parses string inputs into numbers
+  when instantiating a model. Invalid values will cause an error to be thrown.
+* [IntegerField](https://prestojs.com/docs/viewmodel/fields/IntegerField), [FloatField](https://prestojs.com/docs/viewmodel/fields/FloatField) & [DecimalField](https://prestojs.com/docs/viewmodel/fields/DecimalField)
+  used with their default widgets will use `minValue` & `maxValue` to limit the input range
+* [DecimalField](https://prestojs.com/docs/viewmodel/fields/DecimalField) used with [DecimalWidget](https://prestojs.com/docs/ui-antd/widgets/DecimalWidget) will use `decimalPlaces` to limit precision
+* [DecimalWidget](https://prestojs.com/docs/ui-antd/widgets/DecimalWidget) now stores values as a string to allow high precision.
+* [IntegerWidget](https://prestojs.com/docs/ui-antd/widgets/IntegerWidget) now forces entered value to be an integer (ie. decimal places are removed)
+* [NumberField](https://prestojs.com/docs/viewmodel/fields/NumberField) now accepts either string or number for `minValue` & `maxValue` to support strings that may come from `DecimalField`.
 
 ## [0.0.30] - 2022-04-13
 

--- a/doc-site/pages/examples/viewmodel/fields/DecimalField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DecimalField/form-usage.tsx
@@ -1,0 +1,49 @@
+/**
+ * Default widget in a Form
+ *
+ * This example shows the default widget that will be used in a [Form](doc:Form)
+ * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
+ *
+ * The default widget is [DecimalWidget](doc:DecimalWidget). Note that this widget will work with
+ * string values to support high precision.
+ *
+ * @wide
+ * @min-height 320
+ */
+import { Form } from '@prestojs/final-form';
+import { AntdUiProvider, FormItemWrapper, FormWrapper, getWidgetForField } from '@prestojs/ui-antd';
+import { DecimalField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import { Button } from 'antd';
+import 'antd/dist/antd.min.css';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        total: new DecimalField({ decimalPlaces: 2, helpText: 'Enter total to 2 decimal places' }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    return (
+        <React.Suspense fallback="Loading...">
+            <AntdUiProvider
+                getWidgetForField={getWidgetForField}
+                formItemComponent={FormItemWrapper}
+                formComponent={FormWrapper}
+            >
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <Form onSubmit={data => console.log(data)}>
+                        <Form.Item field={ExampleModel.fields.total} />
+                        <Form.Item wrapperCol={{ offset: 6 }}>
+                            <Button type="primary" htmlType="submit">
+                                Submit (check console)
+                            </Button>
+                        </Form.Item>
+                    </Form>
+                </div>
+            </AntdUiProvider>
+        </React.Suspense>
+    );
+}

--- a/doc-site/pages/examples/viewmodel/fields/DecimalField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/DecimalField/formatter-usage.tsx
@@ -1,0 +1,58 @@
+/**
+ * Default formatter for DecimalField
+ *
+ * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
+ *
+ * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `DecimalField` is [NumberFormatter](doc:NumberFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ *  option. These will be passed through to the formatter component (eg. `locales` & `localeOptions`
+ *  in this example).
+ */
+import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
+import { DecimalField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        discount: new DecimalField({
+            formatterProps: {
+                locales: ['en-AU'],
+                localeOptions: { style: 'percent' },
+            },
+        }),
+        total: new DecimalField({
+            label: 'Total Amount',
+        }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    const record = new ExampleModel({
+        id: 1,
+        discount: '0.5',
+        total: '1000.358',
+    });
+    return (
+        <React.Suspense fallback="Loading...">
+            <UiProvider getFormatterForField={getFormatterForField}>
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <dl>
+                        <dt>{ExampleModel.fields.discount.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.discount} />
+                        </dd>
+                        <dt>{ExampleModel.fields.total.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.total} />
+                        </dd>
+                    </dl>
+                </div>
+            </UiProvider>
+        </React.Suspense>
+    );
+}

--- a/doc-site/pages/examples/viewmodel/fields/FloatField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/FloatField/form-usage.tsx
@@ -1,0 +1,48 @@
+/**
+ * Default widget in a Form
+ *
+ * This example shows the default widget that will be used in a [Form](doc:Form)
+ * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
+ *
+ * The default widget is [FloatWidget](doc:FloatWidget).
+ *
+ * @wide
+ * @min-height 320
+ */
+import { Form } from '@prestojs/final-form';
+import { AntdUiProvider, FormItemWrapper, FormWrapper, getWidgetForField } from '@prestojs/ui-antd';
+import { FloatField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import { Button } from 'antd';
+import 'antd/dist/antd.min.css';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        total: new FloatField({ minValue: 0 }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    return (
+        <React.Suspense fallback="Loading...">
+            <AntdUiProvider
+                getWidgetForField={getWidgetForField}
+                formItemComponent={FormItemWrapper}
+                formComponent={FormWrapper}
+            >
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <Form onSubmit={data => console.log(data)}>
+                        <Form.Item field={ExampleModel.fields.total} />
+                        <Form.Item wrapperCol={{ offset: 6 }}>
+                            <Button type="primary" htmlType="submit">
+                                Submit (check console)
+                            </Button>
+                        </Form.Item>
+                    </Form>
+                </div>
+            </AntdUiProvider>
+        </React.Suspense>
+    );
+}

--- a/doc-site/pages/examples/viewmodel/fields/FloatField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/FloatField/formatter-usage.tsx
@@ -1,0 +1,58 @@
+/**
+ * Default formatter for FloatField
+ *
+ * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
+ *
+ * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `FloatField` is [NumberFormatter](doc:NumberFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ *  option. These will be passed through to the formatter component (eg. `locales` & `localeOptions`
+ *  in this example).
+ */
+import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
+import { FloatField, IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        discount: new FloatField({
+            formatterProps: {
+                locales: ['en-AU'],
+                localeOptions: { style: 'percent' },
+            },
+        }),
+        total: new FloatField({
+            label: 'Total Amount',
+        }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    const record = new ExampleModel({
+        id: 1,
+        discount: 0.5,
+        total: 1000.358,
+    });
+    return (
+        <React.Suspense fallback="Loading...">
+            <UiProvider getFormatterForField={getFormatterForField}>
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <dl>
+                        <dt>{ExampleModel.fields.discount.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.discount} />
+                        </dd>
+                        <dt>{ExampleModel.fields.total.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.total} />
+                        </dd>
+                    </dl>
+                </div>
+            </UiProvider>
+        </React.Suspense>
+    );
+}

--- a/doc-site/pages/examples/viewmodel/fields/IntegerField/form-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/IntegerField/form-usage.tsx
@@ -1,0 +1,48 @@
+/**
+ * Default widget in a Form
+ *
+ * This example shows the default widget that will be used in a [Form](doc:Form)
+ * when using [@prestojs/ui-antd](/docs/ui-antd). See [getWidgetForField](doc:getWidgetForField).
+ *
+ * The default widget is [IntegerWidget](doc:IntegerWidget).
+ *
+ * @wide
+ * @min-height 320
+ */
+import { Form } from '@prestojs/final-form';
+import { AntdUiProvider, FormItemWrapper, FormWrapper, getWidgetForField } from '@prestojs/ui-antd';
+import { IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import { Button } from 'antd';
+import 'antd/dist/antd.min.css';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        age: new IntegerField({ minValue: 0, maxValue: 120 }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    return (
+        <React.Suspense fallback="Loading...">
+            <AntdUiProvider
+                getWidgetForField={getWidgetForField}
+                formItemComponent={FormItemWrapper}
+                formComponent={FormWrapper}
+            >
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <Form onSubmit={data => console.log(data)}>
+                        <Form.Item field={ExampleModel.fields.age} />
+                        <Form.Item wrapperCol={{ offset: 6 }}>
+                            <Button type="primary" htmlType="submit">
+                                Submit (check console)
+                            </Button>
+                        </Form.Item>
+                    </Form>
+                </div>
+            </AntdUiProvider>
+        </React.Suspense>
+    );
+}

--- a/doc-site/pages/examples/viewmodel/fields/IntegerField/formatter-usage.tsx
+++ b/doc-site/pages/examples/viewmodel/fields/IntegerField/formatter-usage.tsx
@@ -1,0 +1,50 @@
+/**
+ * Default formatter for IntegerField
+ *
+ * This example shows the default formatter that will be used with [FieldFormatter](doc:FieldFormatter).
+ *
+ * See [getFormatterForField](doc:getFormatterForField) for how a formatter is selected for a field.
+ *
+ * The default formatter for `IntegerField` is [NumberFormatter](doc:NumberFormatter).
+ *
+ * You can pass options for the formatter via the [Field](doc:Field) under the `formatterOptions`
+ *  option. These will be passed through to the formatter component (eg. `locales` & `localeOptions`
+ *  in this example).
+ */
+import { FieldFormatter, getFormatterForField, UiProvider } from '@prestojs/ui';
+import { IntegerField, viewModelFactory } from '@prestojs/viewmodel';
+import React from 'react';
+
+class ExampleModel extends viewModelFactory(
+    {
+        id: new IntegerField(),
+        capacity: new IntegerField({
+            formatterProps: {
+                locales: ['en-AU'],
+                localeOptions: { style: 'unit', unit: 'liter' },
+            },
+        }),
+    },
+    { pkFieldName: 'id' }
+) {}
+
+export default function FormUsage() {
+    const record = new ExampleModel({
+        id: 1,
+        capacity: 50,
+    });
+    return (
+        <React.Suspense fallback="Loading...">
+            <UiProvider getFormatterForField={getFormatterForField}>
+                <div className="grid grid-cols-1 gap-4 w-full">
+                    <dl>
+                        <dt>{ExampleModel.fields.capacity.label}</dt>
+                        <dd>
+                            <FieldFormatter field={record._f.capacity} />
+                        </dd>
+                    </dl>
+                </div>
+            </UiProvider>
+        </React.Suspense>
+    );
+}

--- a/js-packages/@prestojs/ui-antd/src/widgets/DecimalWidget.tsx
+++ b/js-packages/@prestojs/ui-antd/src/widgets/DecimalWidget.tsx
@@ -1,12 +1,14 @@
 import { WidgetProps } from '@prestojs/ui';
 import { InputNumber } from 'antd';
+import { InputNumberProps } from 'antd/lib/input-number';
 import React from 'react';
 
 /**
  * @expand-properties
  * @hide-properties choices asyncChoices
  */
-type DecimalWidgetProps = WidgetProps<string, HTMLInputElement>;
+type DecimalWidgetProps = WidgetProps<string, HTMLInputElement> &
+    Omit<InputNumberProps, 'onChange' | 'value'>;
 
 /**
  * See [InputNumber](https://ant.design/components/input-number/) for props available
@@ -20,10 +22,7 @@ function DecimalWidget(
     ref: React.RefObject<HTMLInputElement>
 ): React.ReactElement {
     const { input, meta, ...rest } = props;
-    const { value, ...restInput } = input;
-    const valueNum: number | null | undefined =
-        value === undefined || value === null ? value : Number(value);
-    return <InputNumber ref={ref} value={valueNum} {...restInput} {...rest} />;
+    return <InputNumber ref={ref} stringMode {...input} {...rest} />;
 }
 
 export default React.forwardRef(DecimalWidget);

--- a/js-packages/@prestojs/ui-antd/src/widgets/FloatWidget.tsx
+++ b/js-packages/@prestojs/ui-antd/src/widgets/FloatWidget.tsx
@@ -1,12 +1,14 @@
 import { WidgetProps } from '@prestojs/ui';
 import { InputNumber } from 'antd';
+import { InputNumberProps } from 'antd/lib/input-number';
 import React from 'react';
 
 /**
  * @expand-properties
  * @hide-properties choices asyncChoices
  */
-type FloatWidgetProps = WidgetProps<number, HTMLInputElement>;
+type FloatWidgetProps = WidgetProps<number, HTMLInputElement> &
+    Omit<InputNumberProps, 'onChange' | 'value'>;
 
 /**
  * See [InputNumber](https://ant.design/components/input-number/) for props available

--- a/js-packages/@prestojs/ui-antd/src/widgets/IntegerWidget.tsx
+++ b/js-packages/@prestojs/ui-antd/src/widgets/IntegerWidget.tsx
@@ -1,12 +1,14 @@
 import { WidgetProps } from '@prestojs/ui';
 import { InputNumber } from 'antd';
+import { InputNumberProps } from 'antd/lib/input-number';
 import React from 'react';
 
 /**
  * @expand-properties
  * @hide-properties choices asyncChoices
  */
-type IntegerWidgetProps = WidgetProps<number, HTMLInputElement>;
+type IntegerWidgetProps = WidgetProps<number, HTMLInputElement> &
+    Omit<InputNumberProps, 'onChange' | 'value'>;
 
 /**
  * See [InputNumber](https://ant.design/components/input-number/) for props available
@@ -20,7 +22,7 @@ function IntegerWidget(
     ref: React.RefObject<HTMLInputElement>
 ): React.ReactElement {
     const { input, meta, ...rest } = props;
-    return <InputNumber ref={ref} {...rest} {...input} />;
+    return <InputNumber ref={ref} precision={0} {...rest} {...input} />;
 }
 
 export default React.forwardRef(IntegerWidget);

--- a/js-packages/@prestojs/viewmodel/src/fields/DecimalField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DecimalField.ts
@@ -1,20 +1,51 @@
+import { ViewModelFieldWidgetProps } from './Field';
 import NumberField, { NumberFieldProps } from './NumberField';
 
 /**
  * @expand-properties
  */
 type DecimalFieldProps = NumberFieldProps<string> & {
+    /**
+     * The number of decimal places that should be accepted
+     */
     decimalPlaces?: number;
 };
 
 /**
- * Decimal Field. Stores decimal value as a string.
+ * A decimal field that stores the value as a string rather than a `number` to support better precision.
  *
+ * This class accepts all the props of [NumberField](doc:NumberField) as well as the optional
+ * `decimalPlaces` properties which can be used by form widgets to limit the accepted values.
+ *
+ * ## Usage
+ *
+ * Use with [viewModelFactory](doc:viewModelFactory).
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   total: new DecimalField(),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
+ * Optionally provide `minValue`, `maxValue`, `decimalPlaces` or any options from [Field](doc:Field):
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   total: new CharField({
+ *     minValue: '0',
+ *     decimalPlaces: 2,
+ *   }),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
+ * <Alert type="info">
  * To support decimal operations consider a custom implementation that uses a decimal library eg. decimal.js
- *
- * Also used by CurrencyField.
+ * </Alert>
  *
  * See also: [FloatField](doc:FloatField)
+ *
  *
  * @extract-docs
  * @menu-group Fields
@@ -44,5 +75,16 @@ export default class DecimalField extends NumberField<string> {
             return null;
         }
         return value;
+    }
+
+    normalize(value: string): string | null {
+        return this.parse(value);
+    }
+
+    getWidgetProps(): ViewModelFieldWidgetProps {
+        return {
+            precision: this.decimalPlaces,
+            ...super.getWidgetProps(),
+        };
     }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/Field.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/Field.ts
@@ -550,7 +550,8 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
      * into a `Date`.
      *
      * This implementation will often match [normalize](#Call-signature-normalize) which performs a similar function
-     * but processes the values received by the `ViewModel`.
+     * but processes the values received by the `ViewModel`. In general `parse` should not throw on invalid input (eg.
+     * user could be part way through entering a value) whereas `normalize` should.
      *
      * @param value The value received from a form widget
      */
@@ -560,26 +561,11 @@ export default class Field<ValueT, ParsableValueT extends any = ValueT, SingleVa
 
     /**
      * Normalize a value passed into a ViewModel constructor. This could do things like parse a date string to
-     * a `Date` or extract the id of a nested relation and only store that, eg.
-     *
-     * ```js
-     * // This might become
-     * value = {
-     *     name: 'Sam',
-     *     address: {
-     *         id: 5,
-     *         formatted: '3 Somewhere Road, Some Place',
-     *     },
-     * }
-     * // ...this
-     * value = {
-     *     name: 'Same',
-     *     address: 5,
-     * }
-     * ```
+     * a `Date`.
      *
      * This implementation will often match [parse](#Call-signature-parse) which performs a similar function
-     * but for values received from a form input.
+     * but for values received from a form input. In general `normalize` should throw on invalid input whereas
+     * `parse` should not.
      *
      * @param value The value to normalize
      */

--- a/js-packages/@prestojs/viewmodel/src/fields/FloatField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/FloatField.ts
@@ -1,28 +1,64 @@
 import NumberField from './NumberField';
 
 /**
- * Float Field.
+ * A field to store floating point values
  *
- * Use only if stored number is tolerant on precision error.
+ * This class accepts all the props of [NumberField](doc:NumberField).
  *
- * See also: [DecimalField](doc:DecimalField)
+ * ## Usage
+ *
+ * Use with [viewModelFactory](doc:viewModelFactory).
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   total: new FloatField(),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
+ * Optionally provide `minValue`, `maxValue` or any options from [Field](doc:Field):
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   total: new CharField({
+ *     minValue: 0,
+ *   }),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
+ * <Alert type="info">
+ * This field stores the value as a [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number). If
+ * you need arbitrary precision use [DecimalField](doc:DecimalField)
+ * </Alert>
  *
  * @extract-docs
  * @menu-group Fields
  */
-export default class FloatField extends NumberField<number> {
+export default class FloatField extends NumberField<number, string | number> {
     static fieldClassName = 'FloatField';
-    parse(value: any): number | null {
+    private _parseValue(value: any, shouldThrow: boolean) {
         // Don't force empty string, null or undefined to a number (which would be 0) -
         // force them both to be null to represent no value set.
         if (value === '' || value == null) {
             return null;
         }
-        const numberValue = Number(value);
         // If we can't parse number just return it as is so as not to break inputs
-        if (Number.isNaN(numberValue)) {
+        if (Number.isNaN(Number(value))) {
+            if (shouldThrow) {
+                throw new Error('Invalid value for FloatField');
+            }
             return value;
         }
-        return numberValue;
+        if (typeof value == 'number') {
+            return value;
+        }
+        return parseFloat(value);
+    }
+    parse(value: any): number | null {
+        return this._parseValue(value, false);
+    }
+    normalize(value: string | number): number | null {
+        return this._parseValue(value, true);
     }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/IntegerField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/IntegerField.ts
@@ -1,18 +1,60 @@
 import NumberField from './NumberField';
 
 /**
+ * A field to store integer values
+ *
+ * This class accepts all the props of [Field](doc:Field) as well as the optional
+ * `minValue` & `maxValue` properties which can be used by form widgets to limit the accepted
+ * values.
+ *
+ * ## Usage
+ *
+ * Use with [viewModelFactory](doc:viewModelFactory).
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   age: new IntegerField(),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
+ * Optionally provide `minValue`, `maxValue` or any options from [Field](doc:Field):
+ *
+ * ```js
+ * viewModelFactory({
+ *   id: new Field(),
+ *   age: new CharField({
+ *     minValue: 0,
+ *     maxValue: 100,
+ *     helpText: 'Enter your age'
+ *   }),
+ * }, { pkFieldName: 'id' });
+ * ```
+ *
  * @extract-docs
  * @menu-group Fields
  */
 export default class IntegerField extends NumberField<number, string | number> {
     static fieldClassName = 'IntegerField';
-    parse(value: any): number | null {
+
+    private _parse(value: any, shouldThrow: boolean): number | null {
         if (value === '' || value == null) {
             return null;
         }
         if (Number.isNaN(Number(value))) {
+            if (shouldThrow) {
+                throw new Error('Invalid value for IntegerField');
+            }
             return value;
         }
         return parseInt(value, 10);
+    }
+
+    parse(value: any): number | null {
+        return this._parse(value, false);
+    }
+
+    normalize(value: string | number): number | null {
+        return this._parse(value, true);
     }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/NumberField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/NumberField.ts
@@ -1,11 +1,17 @@
-import Field, { FieldProps } from './Field';
+import Field, { FieldProps, ViewModelFieldWidgetProps } from './Field';
 
 /**
  * @expand-properties
  */
-export interface NumberFieldProps<T> extends FieldProps<T> {
-    minValue?: number;
-    maxValue?: number;
+export interface NumberFieldProps<ValueT> extends FieldProps<ValueT> {
+    /**
+     * The minimum value that should be accepted
+     */
+    minValue?: ValueT;
+    /**
+     * The maximum value that should be accepted
+     */
+    maxValue?: ValueT;
 }
 
 /**
@@ -48,20 +54,24 @@ export default class NumberField<ValueT = string | number, ParsableValueT = Valu
     ParsableValueT
 > {
     static fieldClassName = 'NumberField';
-    public minValue?: number;
-    public maxValue?: number;
+    public minValue?: ValueT;
+    public maxValue?: ValueT;
 
     constructor(values: NumberFieldProps<ValueT> = {}) {
         const { minValue, maxValue, ...rest } = values;
 
-        if (minValue != null && typeof minValue !== 'number')
+        if (minValue != null && Number.isNaN(Number(minValue)))
             throw new Error(`"minValue" should be a number, received: ${minValue}`);
-        if (maxValue != null && typeof maxValue !== 'number')
+        if (maxValue != null && Number.isNaN(Number(maxValue)))
             throw new Error(`"maxValue" should be a number, received: ${maxValue}`);
 
         super(rest);
 
         this.minValue = minValue;
         this.maxValue = maxValue;
+    }
+
+    getWidgetProps(): ViewModelFieldWidgetProps {
+        return { min: this.minValue, max: this.maxValue, ...super.getWidgetProps() };
     }
 }

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/DecimalField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/DecimalField.test.ts
@@ -10,3 +10,12 @@ test('DecimalField should return values as is', () => {
     expect(field.parse(null)).toBe(null);
     expect(field.parse('asdf')).toBe('asdf');
 });
+
+test('should be able to pass strings for maxValue & minValue', () => {
+    const field = new DecimalField({ minValue: '1.3', maxValue: '2.2' });
+    expect(field.minValue).toBe('1.3');
+    expect(field.maxValue).toBe('2.2');
+
+    expect(() => new DecimalField({ minValue: 'invalid' })).toThrow();
+    expect(() => new DecimalField({ maxValue: 'invalid' })).toThrow();
+});

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/FloatField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/FloatField.test.ts
@@ -1,3 +1,4 @@
+import viewModelFactory from '../../ViewModelFactory';
 import FloatField from '../FloatField';
 
 test('FloatField should parse numeric values as Number', () => {
@@ -11,4 +12,27 @@ test('FloatField should parse numeric values as Number', () => {
     expect(field.parse('.5')).toBe(0.5);
     expect(field.parse('5.')).toBe(5);
     expect(field.parse('asdf')).toBe('asdf');
+});
+
+test('FloatField should normalize incoming values into numbers', () => {
+    const TestModel = viewModelFactory(
+        {
+            id: new FloatField(),
+        },
+        { pkFieldName: 'id' }
+    );
+
+    expect(new TestModel({ id: '1' }).id).toBe(1);
+    expect(new TestModel({ id: 2.5 }).id).toBe(2.5);
+
+    expect(() => new TestModel({ id: 'invalid' })).toThrowError(/Invalid value/);
+});
+
+test('FloatField should support min/max', () => {
+    const field = new FloatField({
+        minValue: 0,
+        maxValue: 5.5,
+    });
+
+    expect(field.getWidgetProps()).toEqual({ min: 0, max: 5.5 });
 });

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/IntegerField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/IntegerField.test.ts
@@ -1,3 +1,4 @@
+import viewModelFactory from '../../ViewModelFactory';
 import IntegerField from '../IntegerField';
 
 test('IntegerField should parse numeric values as Int', () => {
@@ -9,4 +10,18 @@ test('IntegerField should parse numeric values as Int', () => {
     expect(field.parse('0')).toBe(0);
     expect(field.parse('')).toBe(null);
     expect(field.parse('asdf')).toBe('asdf');
+});
+
+test('IntegerField should normalize incoming values into numbers', () => {
+    const TestModel = viewModelFactory(
+        {
+            id: new IntegerField(),
+        },
+        { pkFieldName: 'id' }
+    );
+
+    expect(new TestModel({ id: '1' }).id).toBe(1);
+    expect(new TestModel({ id: 2.5 }).id).toBe(2);
+
+    expect(() => new TestModel({ id: 'invalid' })).toThrowError(/Invalid value/);
 });


### PR DESCRIPTION
- Adds parse/normalize to IntegerField, FloatField & DecimalField
- Fix widget types to accept underlying antd props
- Pass min/max through to widget
- IntegerWidget sets precision to 0
- DecimalWidget sets precision based on DecimalField `decimalPlaces`
- DecimalWidget now uses string values rather than converting to `number` (makes use of antd InputNumber `stringMode`)