### PR TITLE
fix: DateField/DateTimeField isEqual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 * [DecimalWidget](https://prestojs.com/docs/ui-antd/widgets/DecimalWidget) now stores values as a string to allow high precision.
 * [IntegerWidget](https://prestojs.com/docs/ui-antd/widgets/IntegerWidget) now forces entered value to be an integer (ie. decimal places are removed)
 * [NumberField](https://prestojs.com/docs/viewmodel/fields/NumberField) now accepts either string or number for `minValue` & `maxValue` to support strings that may come from `DecimalField`.
+* [DateField](https://prestojs.com/docs/viewmodel/fields/DateField) & [DateTimeField](https://prestojs.com/docs/viewmodel/fields/DateTimeField) now consider dates that represent the same value to be equal
+  * Without this change if a record with one of these fields was to be updated via `viewModelCachingMiddleware` and it was identical it would still always replace the existing record.
 
 ## [0.0.30] - 2022-04-13
 

--- a/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
@@ -22,15 +22,17 @@ export default class DateField extends Field<Date, string | Date> {
     }
 
     isEqual(a?: Date, b?: Date): boolean {
+        if (a === b) {
+            return true;
+        }
         if (!a || !b) {
             return false;
         }
         return (
-            a === b ||
             // We only compare date components as there's technically no time component for DateField
-            (a.getFullYear() === b.getFullYear() &&
-                a.getMonth() === b.getMonth() &&
-                a.getDate() === b.getDate())
+            a.getFullYear() === b.getFullYear() &&
+            a.getMonth() === b.getMonth() &&
+            a.getDate() === b.getDate()
         );
     }
 

--- a/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateField.ts
@@ -21,6 +21,19 @@ export default class DateField extends Field<Date, string | Date> {
         return new Date(value);
     }
 
+    isEqual(a?: Date, b?: Date): boolean {
+        if (!a || !b) {
+            return false;
+        }
+        return (
+            a === b ||
+            // We only compare date components as there's technically no time component for DateField
+            (a.getFullYear() === b.getFullYear() &&
+                a.getMonth() === b.getMonth() &&
+                a.getDate() === b.getDate())
+        );
+    }
+
     normalize(value: string | Date): Date | null {
         if (value instanceof Date) {
             return value;

--- a/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
@@ -18,6 +18,12 @@ export default class DateTimeField extends Field<Date, string | Date> {
         }
         return new Date(value);
     }
+    isEqual(a?: Date, b?: Date): boolean {
+        if (!a || !b) {
+            return false;
+        }
+        return a === b || a.getTime() === b.getTime();
+    }
     normalize(value: string | Date): Date | null {
         if (value instanceof Date) {
             return value;

--- a/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/DateTimeField.ts
@@ -19,10 +19,13 @@ export default class DateTimeField extends Field<Date, string | Date> {
         return new Date(value);
     }
     isEqual(a?: Date, b?: Date): boolean {
+        if (a === b) {
+            return true;
+        }
         if (!a || !b) {
             return false;
         }
-        return a === b || a.getTime() === b.getTime();
+        return a.getTime() === b.getTime();
     }
     normalize(value: string | Date): Date | null {
         if (value instanceof Date) {

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateField.test.ts
@@ -11,3 +11,21 @@ test('DateField parse values correctly', () => {
     const now = new Date();
     expect((field.parse(now) as Date).toISOString()).toBe(now.toISOString());
 });
+
+test('should consider distinct date instances with same date as equal', () => {
+    const field = new DateField({ label: 'date' });
+    const a = field.parse('2019-11-25') as Date;
+    const b = field.parse('2019-11-25') as Date;
+    const c = field.parse('2019-11-26') as Date;
+    const d = field.parse('2018-11-25') as Date;
+    const e = field.parse('2019-10-25') as Date;
+    // time component ignored
+    const f = field.parse('2019-11-25 10:00:58 GMT+0') as Date;
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(field.isEqual(a, b)).toBe(true);
+    expect(field.isEqual(a, c)).toBe(false);
+    expect(field.isEqual(a, d)).toBe(false);
+    expect(field.isEqual(a, e)).toBe(false);
+    expect(field.isEqual(a, f)).toBe(true);
+});

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateField.test.ts
@@ -28,4 +28,5 @@ test('should consider distinct date instances with same date as equal', () => {
     expect(field.isEqual(a, d)).toBe(false);
     expect(field.isEqual(a, e)).toBe(false);
     expect(field.isEqual(a, f)).toBe(true);
+    expect(field.isEqual(undefined, undefined)).toBe(true);
 });

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateTimeField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateTimeField.test.ts
@@ -13,3 +13,19 @@ test('DateTimeField parse values correctly', () => {
     const now = new Date();
     expect((field.parse(now) as Date).toISOString()).toBe(now.toISOString());
 });
+test('should consider distinct datetime instances with same date + time as equal', () => {
+    const field = new DateTimeField({ label: 'date' });
+    const a = field.parse('2019-11-25 23:59:59 GMT+0') as Date;
+    const b = field.parse('2019-11-25 23:59:59 GMT+0') as Date;
+    const c = field.parse('2019-11-26 23:59:59 GMT+0') as Date;
+    const d = field.parse('2018-11-25 23:59:59 GMT+0') as Date;
+    const e = field.parse('2019-10-25 23:59:59 GMT+0') as Date;
+    const f = field.parse('2019-11-25 23:59:58 GMT+0') as Date;
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(field.isEqual(a, b)).toBe(true);
+    expect(field.isEqual(a, c)).toBe(false);
+    expect(field.isEqual(a, d)).toBe(false);
+    expect(field.isEqual(a, e)).toBe(false);
+    expect(field.isEqual(a, f)).toBe(false);
+});

--- a/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateTimeField.test.ts
+++ b/js-packages/@prestojs/viewmodel/src/fields/__tests__/DateTimeField.test.ts
@@ -28,4 +28,5 @@ test('should consider distinct datetime instances with same date + time as equal
     expect(field.isEqual(a, d)).toBe(false);
     expect(field.isEqual(a, e)).toBe(false);
     expect(field.isEqual(a, f)).toBe(false);
+    expect(field.isEqual(undefined, undefined)).toBe(true);
 });


### PR DESCRIPTION
- DateField and DateTimeField now consider dates that represent the same
  date or datetime as equal
- This is important for caching otherwise a record with these fields will
  never be considered equal (eg. when record comes from API endpoint via
  viewModelCachingMiddleware it will construct an instance of the viewmodel
  then do an isEqual check to see if it differs from existing record)

Resolves #157 