### PR TITLE
Feature/endpoint docs and extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   * `baseUrl` - if specified this will be prefixed to resolved pattern
   * `query` - any query parameters to be included in any urls resolved from this pattern
   * `mergeQuery` - If true (the default) then any query parameters provided to the constructor will be merged with any provided to resolve.
+* [Endpoint.prepare](https://prestojs.com/docs/rest/Endpoint#Method-prepare) now returns a function that can be called directly (previously it was an object with an `execute` method). 
+  * This changes usage from `endpoint.prepare().execute()` to `endpoint.prepare()()` (but the former will still work with a deprecation notice)
+  * This makes usage with useAsync much easier, eg. `useAsync(endpoint.prepare(), { trigger: 'SHALLOW' })` will work now
+* [Endpoint](https://prestojs.com/docs/rest/Endpoint#api) now accepts a `string` or `UrlPattern` as the URL. If a `string` is passed it will be converted to a `UrlPattern`.
 
 ### Types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Fix bug in view model caching when retrieving nested records with many related fields with no values set. Previously
   if it was initialised with an empty array retrieving from the cache explicitly naming those fields (or using *) would
   result in a cache miss.
+* [UrlPattern](https://prestojs.com/docs/routing/UrlPattern#UrlPattern) now supports specifying options in the constructor. All options can be overridden in the call to `resolve`.
+  * `baseUrl` - if specified this will be prefixed to resolved pattern
+  * `query` - any query parameters to be included in any urls resolved from this pattern
+  * `mergeQuery` - If true (the default) then any query parameters provided to the constructor will be merged with any provided to resolve.
 
 ### Types
 

--- a/doc-site/components/MdxPage.tsx
+++ b/doc-site/components/MdxPage.tsx
@@ -36,6 +36,7 @@ function extractHeadings(children) {
             section.links.push({
                 title: title,
                 anchorId,
+                links: [],
             });
         }
         return <div />;

--- a/doc-site/pages/api/paginated-users.js
+++ b/doc-site/pages/api/paginated-users.js
@@ -1,0 +1,20 @@
+// Fake users data
+import users from './users.json';
+
+export default function handler(req, res) {
+    const { filter } = req.query;
+    const page = Number(req.query.page || 1);
+    const pageSize = Number(req.query.pageSize || 10);
+    const start = (page - 1) * pageSize;
+    let filteredUsers = users;
+    if (filter) {
+        filteredUsers = filteredUsers.filter(user =>
+            user.name.toLowerCase().includes(filter.toLowerCase())
+        );
+    }
+    res.status(200).json({
+        count: filteredUsers.length,
+        results: filteredUsers.slice(start, start + pageSize),
+        pageSize,
+    });
+}

--- a/doc-site/pages/api/user/[id].js
+++ b/doc-site/pages/api/user/[id].js
@@ -1,0 +1,20 @@
+export default function userHandler(req, res) {
+    const {
+        query: { id, name },
+        method,
+    } = req;
+
+    switch (method) {
+        case 'GET':
+            // Get data from your database
+            res.status(200).json({ id, name: `User ${id}` });
+            break;
+        case 'PUT':
+            // Update or create data in your database
+            res.status(200).json({ id, name: name || `User ${id}` });
+            break;
+        default:
+            res.setHeader('Allow', ['GET', 'PUT']);
+            res.status(405).end(`Method ${method} Not Allowed`);
+    }
+}

--- a/doc-site/pages/api/users.js
+++ b/doc-site/pages/api/users.js
@@ -1,0 +1,13 @@
+// Fake users data
+import users from './users.json';
+
+export default function handler(req, res) {
+    const { filter } = req.query;
+    let filteredUsers = users.slice(0, 10);
+    if (filter) {
+        filteredUsers = filteredUsers.filter(user =>
+            user.name.toLowerCase().includes(filter.toLowerCase())
+        );
+    }
+    res.status(200).json(filteredUsers);
+}

--- a/doc-site/pages/api/users.json
+++ b/doc-site/pages/api/users.json
@@ -1,0 +1,1002 @@
+[
+  {
+    "name": "Riley Strickland",
+    "id": 1,
+    "registeredOn": "2023-05-11"
+  },
+  {
+    "name": "Alexandra Diaz",
+    "id": 2,
+    "registeredOn": "2023-06-07"
+  },
+  {
+    "name": "Fritz Wilcox",
+    "id": 3,
+    "registeredOn": "2021-12-04"
+  },
+  {
+    "name": "Zelda Henson",
+    "id": 4,
+    "registeredOn": "2022-06-19"
+  },
+  {
+    "name": "Fritz Oneal",
+    "id": 5,
+    "registeredOn": "2022-09-26"
+  },
+  {
+    "name": "Giacomo Sanders",
+    "id": 6,
+    "registeredOn": "2022-10-02"
+  },
+  {
+    "name": "Eve Mccullough",
+    "id": 7,
+    "registeredOn": "2022-04-01"
+  },
+  {
+    "name": "Dante Cohen",
+    "id": 8,
+    "registeredOn": "2023-01-22"
+  },
+  {
+    "name": "Aquila Glenn",
+    "id": 9,
+    "registeredOn": "2021-10-26"
+  },
+  {
+    "name": "Illana Taylor",
+    "id": 10,
+    "registeredOn": "2021-10-20"
+  },
+  {
+    "name": "Sophia Welch",
+    "id": 11,
+    "registeredOn": "2021-09-21"
+  },
+  {
+    "name": "Roanna Barrera",
+    "id": 12,
+    "registeredOn": "2021-11-26"
+  },
+  {
+    "name": "Brennan Mcintosh",
+    "id": 13,
+    "registeredOn": "2021-10-10"
+  },
+  {
+    "name": "Hamilton Lowe",
+    "id": 14,
+    "registeredOn": "2023-08-18"
+  },
+  {
+    "name": "Malcolm Mcguire",
+    "id": 15,
+    "registeredOn": "2021-10-24"
+  },
+  {
+    "name": "Moses Mayo",
+    "id": 16,
+    "registeredOn": "2022-08-17"
+  },
+  {
+    "name": "Oscar Munoz",
+    "id": 17,
+    "registeredOn": "2022-06-26"
+  },
+  {
+    "name": "Hilel Berg",
+    "id": 18,
+    "registeredOn": "2023-07-07"
+  },
+  {
+    "name": "Whitney Velazquez",
+    "id": 19,
+    "registeredOn": "2022-07-09"
+  },
+  {
+    "name": "Colby Battle",
+    "id": 20,
+    "registeredOn": "2022-05-05"
+  },
+  {
+    "name": "Dustin Gentry",
+    "id": 21,
+    "registeredOn": "2022-07-21"
+  },
+  {
+    "name": "Forrest Reid",
+    "id": 22,
+    "registeredOn": "2021-12-22"
+  },
+  {
+    "name": "Debra Bray",
+    "id": 23,
+    "registeredOn": "2023-01-22"
+  },
+  {
+    "name": "Bevis Randall",
+    "id": 24,
+    "registeredOn": "2023-07-31"
+  },
+  {
+    "name": "Alvin Roy",
+    "id": 25,
+    "registeredOn": "2022-11-06"
+  },
+  {
+    "name": "Rebecca Anderson",
+    "id": 26,
+    "registeredOn": "2022-06-22"
+  },
+  {
+    "name": "Keaton Burns",
+    "id": 27,
+    "registeredOn": "2023-05-27"
+  },
+  {
+    "name": "Branden Langley",
+    "id": 28,
+    "registeredOn": "2021-11-02"
+  },
+  {
+    "name": "Allen Erickson",
+    "id": 29,
+    "registeredOn": "2021-10-08"
+  },
+  {
+    "name": "Keelie Calderon",
+    "id": 30,
+    "registeredOn": "2022-08-07"
+  },
+  {
+    "name": "Calista Hawkins",
+    "id": 31,
+    "registeredOn": "2023-01-17"
+  },
+  {
+    "name": "Brielle Davenport",
+    "id": 32,
+    "registeredOn": "2022-05-09"
+  },
+  {
+    "name": "Giacomo Lawson",
+    "id": 33,
+    "registeredOn": "2022-06-03"
+  },
+  {
+    "name": "Britanney Barker",
+    "id": 34,
+    "registeredOn": "2021-11-05"
+  },
+  {
+    "name": "Aaron Jarvis",
+    "id": 35,
+    "registeredOn": "2022-06-10"
+  },
+  {
+    "name": "Winifred Turner",
+    "id": 36,
+    "registeredOn": "2021-11-07"
+  },
+  {
+    "name": "Illiana Rosario",
+    "id": 37,
+    "registeredOn": "2022-04-04"
+  },
+  {
+    "name": "Maris Pearson",
+    "id": 38,
+    "registeredOn": "2022-11-28"
+  },
+  {
+    "name": "Hannah Morales",
+    "id": 39,
+    "registeredOn": "2022-01-07"
+  },
+  {
+    "name": "Martena Valentine",
+    "id": 40,
+    "registeredOn": "2022-12-26"
+  },
+  {
+    "name": "Isaiah Henson",
+    "id": 41,
+    "registeredOn": "2022-01-04"
+  },
+  {
+    "name": "Jorden Christian",
+    "id": 42,
+    "registeredOn": "2022-12-24"
+  },
+  {
+    "name": "Lyle York",
+    "id": 43,
+    "registeredOn": "2022-01-30"
+  },
+  {
+    "name": "Nissim Cervantes",
+    "id": 44,
+    "registeredOn": "2023-02-03"
+  },
+  {
+    "name": "Gregory Moran",
+    "id": 45,
+    "registeredOn": "2021-11-27"
+  },
+  {
+    "name": "Zia Doyle",
+    "id": 46,
+    "registeredOn": "2021-09-05"
+  },
+  {
+    "name": "Maxwell Mckee",
+    "id": 47,
+    "registeredOn": "2022-01-19"
+  },
+  {
+    "name": "Chanda Porter",
+    "id": 48,
+    "registeredOn": "2022-01-22"
+  },
+  {
+    "name": "Gwendolyn Humphrey",
+    "id": 49,
+    "registeredOn": "2023-06-20"
+  },
+  {
+    "name": "Wyoming Franco",
+    "id": 50,
+    "registeredOn": "2023-01-31"
+  },
+  {
+    "name": "Myra Williams",
+    "id": 51,
+    "registeredOn": "2023-01-19"
+  },
+  {
+    "name": "Camilla Castro",
+    "id": 52,
+    "registeredOn": "2023-04-10"
+  },
+  {
+    "name": "Raphael Sloan",
+    "id": 53,
+    "registeredOn": "2023-01-25"
+  },
+  {
+    "name": "Josephine Berger",
+    "id": 54,
+    "registeredOn": "2021-12-20"
+  },
+  {
+    "name": "Vanna Neal",
+    "id": 55,
+    "registeredOn": "2022-03-08"
+  },
+  {
+    "name": "Timon Sweeney",
+    "id": 56,
+    "registeredOn": "2022-02-19"
+  },
+  {
+    "name": "Tobias Christian",
+    "id": 57,
+    "registeredOn": "2022-05-11"
+  },
+  {
+    "name": "Lynn Finley",
+    "id": 58,
+    "registeredOn": "2022-05-19"
+  },
+  {
+    "name": "Mohammad Warner",
+    "id": 59,
+    "registeredOn": "2023-07-11"
+  },
+  {
+    "name": "Shad Frederick",
+    "id": 60,
+    "registeredOn": "2021-12-21"
+  },
+  {
+    "name": "Caldwell Thornton",
+    "id": 61,
+    "registeredOn": "2022-10-07"
+  },
+  {
+    "name": "Nelle Thomas",
+    "id": 62,
+    "registeredOn": "2022-12-13"
+  },
+  {
+    "name": "Arden Patterson",
+    "id": 63,
+    "registeredOn": "2021-12-02"
+  },
+  {
+    "name": "Keane Golden",
+    "id": 64,
+    "registeredOn": "2023-07-07"
+  },
+  {
+    "name": "Thaddeus Hammond",
+    "id": 65,
+    "registeredOn": "2022-02-25"
+  },
+  {
+    "name": "Oprah Griffith",
+    "id": 66,
+    "registeredOn": "2022-10-07"
+  },
+  {
+    "name": "Miriam Roth",
+    "id": 67,
+    "registeredOn": "2023-02-19"
+  },
+  {
+    "name": "Samuel Kidd",
+    "id": 68,
+    "registeredOn": "2023-03-07"
+  },
+  {
+    "name": "Phoebe Montoya",
+    "id": 69,
+    "registeredOn": "2023-02-21"
+  },
+  {
+    "name": "Meredith Frazier",
+    "id": 70,
+    "registeredOn": "2023-03-04"
+  },
+  {
+    "name": "Imogene Tucker",
+    "id": 71,
+    "registeredOn": "2022-07-03"
+  },
+  {
+    "name": "Candice Schwartz",
+    "id": 72,
+    "registeredOn": "2021-10-15"
+  },
+  {
+    "name": "Orson Mercado",
+    "id": 73,
+    "registeredOn": "2023-05-23"
+  },
+  {
+    "name": "Hu Marks",
+    "id": 74,
+    "registeredOn": "2022-02-24"
+  },
+  {
+    "name": "Meghan Horton",
+    "id": 75,
+    "registeredOn": "2023-07-16"
+  },
+  {
+    "name": "Clinton Mcconnell",
+    "id": 76,
+    "registeredOn": "2023-03-31"
+  },
+  {
+    "name": "Rhoda Dunn",
+    "id": 77,
+    "registeredOn": "2022-05-24"
+  },
+  {
+    "name": "Wanda Ramirez",
+    "id": 78,
+    "registeredOn": "2022-11-16"
+  },
+  {
+    "name": "Amethyst Battle",
+    "id": 79,
+    "registeredOn": "2022-02-19"
+  },
+  {
+    "name": "Byron Franks",
+    "id": 80,
+    "registeredOn": "2023-05-17"
+  },
+  {
+    "name": "Justine Guzman",
+    "id": 81,
+    "registeredOn": "2023-07-20"
+  },
+  {
+    "name": "Ishmael Witt",
+    "id": 82,
+    "registeredOn": "2022-08-07"
+  },
+  {
+    "name": "Eaton Nguyen",
+    "id": 83,
+    "registeredOn": "2022-05-11"
+  },
+  {
+    "name": "Ivan Snider",
+    "id": 84,
+    "registeredOn": "2021-12-15"
+  },
+  {
+    "name": "Maggy Battle",
+    "id": 85,
+    "registeredOn": "2022-05-10"
+  },
+  {
+    "name": "Aphrodite Stewart",
+    "id": 86,
+    "registeredOn": "2022-04-13"
+  },
+  {
+    "name": "Aurelia Meyer",
+    "id": 87,
+    "registeredOn": "2021-10-04"
+  },
+  {
+    "name": "Kaitlin Calderon",
+    "id": 88,
+    "registeredOn": "2023-01-03"
+  },
+  {
+    "name": "Sybill Mack",
+    "id": 89,
+    "registeredOn": "2023-07-26"
+  },
+  {
+    "name": "Anjolie Dawson",
+    "id": 90,
+    "registeredOn": "2022-09-30"
+  },
+  {
+    "name": "Kay Chapman",
+    "id": 91,
+    "registeredOn": "2021-10-23"
+  },
+  {
+    "name": "Zoe Booth",
+    "id": 92,
+    "registeredOn": "2023-02-20"
+  },
+  {
+    "name": "Warren Tyler",
+    "id": 93,
+    "registeredOn": "2022-08-23"
+  },
+  {
+    "name": "Imani Duffy",
+    "id": 94,
+    "registeredOn": "2023-03-29"
+  },
+  {
+    "name": "Stacey Thornton",
+    "id": 95,
+    "registeredOn": "2021-09-17"
+  },
+  {
+    "name": "Quintessa Noel",
+    "id": 96,
+    "registeredOn": "2023-01-26"
+  },
+  {
+    "name": "Hedy Ellis",
+    "id": 97,
+    "registeredOn": "2022-01-30"
+  },
+  {
+    "name": "Kenneth Acevedo",
+    "id": 98,
+    "registeredOn": "2021-09-14"
+  },
+  {
+    "name": "Tad Farley",
+    "id": 99,
+    "registeredOn": "2022-01-08"
+  },
+  {
+    "name": "Althea Steele",
+    "id": 100,
+    "registeredOn": "2021-11-12"
+  },
+  {
+    "name": "Bradley Berger",
+    "id": 101,
+    "registeredOn": "2021-11-09"
+  },
+  {
+    "name": "Charde Rogers",
+    "id": 102,
+    "registeredOn": "2022-03-16"
+  },
+  {
+    "name": "Brielle Delacruz",
+    "id": 103,
+    "registeredOn": "2022-03-12"
+  },
+  {
+    "name": "Bert Winters",
+    "id": 104,
+    "registeredOn": "2023-02-03"
+  },
+  {
+    "name": "Gail Bond",
+    "id": 105,
+    "registeredOn": "2022-07-18"
+  },
+  {
+    "name": "Coby Gould",
+    "id": 106,
+    "registeredOn": "2022-05-10"
+  },
+  {
+    "name": "Ora Zamora",
+    "id": 107,
+    "registeredOn": "2022-02-11"
+  },
+  {
+    "name": "Mariko Tate",
+    "id": 108,
+    "registeredOn": "2023-08-17"
+  },
+  {
+    "name": "Odysseus Hall",
+    "id": 109,
+    "registeredOn": "2023-06-24"
+  },
+  {
+    "name": "Lewis Good",
+    "id": 110,
+    "registeredOn": "2022-11-14"
+  },
+  {
+    "name": "Jessica Bentley",
+    "id": 111,
+    "registeredOn": "2021-08-20"
+  },
+  {
+    "name": "Ryder Callahan",
+    "id": 112,
+    "registeredOn": "2022-11-20"
+  },
+  {
+    "name": "Ori Briggs",
+    "id": 113,
+    "registeredOn": "2022-04-23"
+  },
+  {
+    "name": "Tanek Savage",
+    "id": 114,
+    "registeredOn": "2022-11-17"
+  },
+  {
+    "name": "Georgia Bridges",
+    "id": 115,
+    "registeredOn": "2021-11-16"
+  },
+  {
+    "name": "Patrick Reilly",
+    "id": 116,
+    "registeredOn": "2021-11-30"
+  },
+  {
+    "name": "Fuller Mcpherson",
+    "id": 117,
+    "registeredOn": "2021-12-04"
+  },
+  {
+    "name": "Hop Mcknight",
+    "id": 118,
+    "registeredOn": "2023-07-19"
+  },
+  {
+    "name": "Chancellor Forbes",
+    "id": 119,
+    "registeredOn": "2022-10-30"
+  },
+  {
+    "name": "Ethan Franklin",
+    "id": 120,
+    "registeredOn": "2022-02-17"
+  },
+  {
+    "name": "Amethyst Donovan",
+    "id": 121,
+    "registeredOn": "2021-12-19"
+  },
+  {
+    "name": "Hunter Lara",
+    "id": 122,
+    "registeredOn": "2022-06-23"
+  },
+  {
+    "name": "Charde Gates",
+    "id": 123,
+    "registeredOn": "2022-06-03"
+  },
+  {
+    "name": "Phelan Townsend",
+    "id": 124,
+    "registeredOn": "2021-10-01"
+  },
+  {
+    "name": "Grace Parker",
+    "id": 125,
+    "registeredOn": "2021-11-26"
+  },
+  {
+    "name": "Tamara Todd",
+    "id": 126,
+    "registeredOn": "2021-10-15"
+  },
+  {
+    "name": "Daniel Huffman",
+    "id": 127,
+    "registeredOn": "2022-11-12"
+  },
+  {
+    "name": "Clarke Prince",
+    "id": 128,
+    "registeredOn": "2023-01-27"
+  },
+  {
+    "name": "Bryar Rhodes",
+    "id": 129,
+    "registeredOn": "2022-10-02"
+  },
+  {
+    "name": "Laurel Bradley",
+    "id": 130,
+    "registeredOn": "2022-11-05"
+  },
+  {
+    "name": "Quinn Marsh",
+    "id": 131,
+    "registeredOn": "2021-11-18"
+  },
+  {
+    "name": "Clementine Smith",
+    "id": 132,
+    "registeredOn": "2022-09-01"
+  },
+  {
+    "name": "Orson Sweeney",
+    "id": 133,
+    "registeredOn": "2022-01-26"
+  },
+  {
+    "name": "Cruz Powell",
+    "id": 134,
+    "registeredOn": "2022-12-06"
+  },
+  {
+    "name": "Arden Harmon",
+    "id": 135,
+    "registeredOn": "2023-01-04"
+  },
+  {
+    "name": "Ella Hamilton",
+    "id": 136,
+    "registeredOn": "2022-03-15"
+  },
+  {
+    "name": "Nash Neal",
+    "id": 137,
+    "registeredOn": "2022-12-01"
+  },
+  {
+    "name": "Myles Lowe",
+    "id": 138,
+    "registeredOn": "2021-10-01"
+  },
+  {
+    "name": "Chandler Gates",
+    "id": 139,
+    "registeredOn": "2022-11-25"
+  },
+  {
+    "name": "Winifred Skinner",
+    "id": 140,
+    "registeredOn": "2021-09-30"
+  },
+  {
+    "name": "Ishmael Vaughan",
+    "id": 141,
+    "registeredOn": "2021-12-21"
+  },
+  {
+    "name": "Shelley Valencia",
+    "id": 142,
+    "registeredOn": "2021-11-12"
+  },
+  {
+    "name": "Dylan Garner",
+    "id": 143,
+    "registeredOn": "2022-04-10"
+  },
+  {
+    "name": "Timothy Watson",
+    "id": 144,
+    "registeredOn": "2022-02-24"
+  },
+  {
+    "name": "Dominic Kaufman",
+    "id": 145,
+    "registeredOn": "2023-06-01"
+  },
+  {
+    "name": "Chandler Goodwin",
+    "id": 146,
+    "registeredOn": "2023-02-26"
+  },
+  {
+    "name": "Xavier Harrell",
+    "id": 147,
+    "registeredOn": "2023-02-23"
+  },
+  {
+    "name": "Hashim Dudley",
+    "id": 148,
+    "registeredOn": "2022-12-26"
+  },
+  {
+    "name": "Fritz Holman",
+    "id": 149,
+    "registeredOn": "2023-02-05"
+  },
+  {
+    "name": "Cadman Good",
+    "id": 150,
+    "registeredOn": "2021-12-18"
+  },
+  {
+    "name": "Jeremy Chan",
+    "id": 151,
+    "registeredOn": "2022-11-18"
+  },
+  {
+    "name": "Sophia Hammond",
+    "id": 152,
+    "registeredOn": "2022-04-09"
+  },
+  {
+    "name": "Elmo Leon",
+    "id": 153,
+    "registeredOn": "2022-12-30"
+  },
+  {
+    "name": "Xandra Wilson",
+    "id": 154,
+    "registeredOn": "2021-12-15"
+  },
+  {
+    "name": "Raymond Bird",
+    "id": 155,
+    "registeredOn": "2022-07-25"
+  },
+  {
+    "name": "Imani House",
+    "id": 156,
+    "registeredOn": "2022-01-07"
+  },
+  {
+    "name": "Shay Gilbert",
+    "id": 157,
+    "registeredOn": "2022-11-23"
+  },
+  {
+    "name": "Meghan Montoya",
+    "id": 158,
+    "registeredOn": "2022-08-27"
+  },
+  {
+    "name": "Christen Kelly",
+    "id": 159,
+    "registeredOn": "2022-08-27"
+  },
+  {
+    "name": "Miranda Gamble",
+    "id": 160,
+    "registeredOn": "2022-05-14"
+  },
+  {
+    "name": "Nerea Mooney",
+    "id": 161,
+    "registeredOn": "2023-05-05"
+  },
+  {
+    "name": "Sophia Williams",
+    "id": 162,
+    "registeredOn": "2022-03-22"
+  },
+  {
+    "name": "Caryn Galloway",
+    "id": 163,
+    "registeredOn": "2021-11-26"
+  },
+  {
+    "name": "Kennan Lloyd",
+    "id": 164,
+    "registeredOn": "2023-08-03"
+  },
+  {
+    "name": "Medge Johnston",
+    "id": 165,
+    "registeredOn": "2023-02-14"
+  },
+  {
+    "name": "Pamela Atkins",
+    "id": 166,
+    "registeredOn": "2023-06-14"
+  },
+  {
+    "name": "Cheryl Phelps",
+    "id": 167,
+    "registeredOn": "2022-06-17"
+  },
+  {
+    "name": "Aiko Ferrell",
+    "id": 168,
+    "registeredOn": "2022-06-08"
+  },
+  {
+    "name": "Chase Zamora",
+    "id": 169,
+    "registeredOn": "2022-09-24"
+  },
+  {
+    "name": "Yuri Preston",
+    "id": 170,
+    "registeredOn": "2022-02-06"
+  },
+  {
+    "name": "Chandler Kelley",
+    "id": 171,
+    "registeredOn": "2022-08-01"
+  },
+  {
+    "name": "Ora Strickland",
+    "id": 172,
+    "registeredOn": "2022-11-24"
+  },
+  {
+    "name": "Urielle Hogan",
+    "id": 173,
+    "registeredOn": "2021-11-10"
+  },
+  {
+    "name": "Alexander Whitley",
+    "id": 174,
+    "registeredOn": "2022-12-21"
+  },
+  {
+    "name": "Joseph English",
+    "id": 175,
+    "registeredOn": "2022-10-24"
+  },
+  {
+    "name": "Neil Gonzalez",
+    "id": 176,
+    "registeredOn": "2022-12-02"
+  },
+  {
+    "name": "Isaiah Wilder",
+    "id": 177,
+    "registeredOn": "2021-10-14"
+  },
+  {
+    "name": "Harlan Hansen",
+    "id": 178,
+    "registeredOn": "2023-04-06"
+  },
+  {
+    "name": "Remedios Sweeney",
+    "id": 179,
+    "registeredOn": "2023-07-01"
+  },
+  {
+    "name": "Kane Lott",
+    "id": 180,
+    "registeredOn": "2023-05-15"
+  },
+  {
+    "name": "Kiona Steele",
+    "id": 181,
+    "registeredOn": "2022-01-12"
+  },
+  {
+    "name": "Gregory Stewart",
+    "id": 182,
+    "registeredOn": "2022-07-18"
+  },
+  {
+    "name": "Rana Sanders",
+    "id": 183,
+    "registeredOn": "2023-07-04"
+  },
+  {
+    "name": "Aquila Shelton",
+    "id": 184,
+    "registeredOn": "2022-08-11"
+  },
+  {
+    "name": "Kylie Davidson",
+    "id": 185,
+    "registeredOn": "2023-04-24"
+  },
+  {
+    "name": "Sara Whitaker",
+    "id": 186,
+    "registeredOn": "2022-12-24"
+  },
+  {
+    "name": "Violet Barker",
+    "id": 187,
+    "registeredOn": "2022-11-08"
+  },
+  {
+    "name": "Justin Pugh",
+    "id": 188,
+    "registeredOn": "2023-02-06"
+  },
+  {
+    "name": "Urielle Wheeler",
+    "id": 189,
+    "registeredOn": "2022-05-01"
+  },
+  {
+    "name": "Davis Hill",
+    "id": 190,
+    "registeredOn": "2023-05-17"
+  },
+  {
+    "name": "Walker Cardenas",
+    "id": 191,
+    "registeredOn": "2022-07-27"
+  },
+  {
+    "name": "Amal Slater",
+    "id": 192,
+    "registeredOn": "2021-10-26"
+  },
+  {
+    "name": "Delilah Snyder",
+    "id": 193,
+    "registeredOn": "2022-12-23"
+  },
+  {
+    "name": "Susan Patel",
+    "id": 194,
+    "registeredOn": "2022-10-15"
+  },
+  {
+    "name": "Abel Garrison",
+    "id": 195,
+    "registeredOn": "2023-01-20"
+  },
+  {
+    "name": "Katell Melton",
+    "id": 196,
+    "registeredOn": "2023-06-08"
+  },
+  {
+    "name": "Ila Barrera",
+    "id": 197,
+    "registeredOn": "2023-05-28"
+  },
+  {
+    "name": "Nash Copeland",
+    "id": 198,
+    "registeredOn": "2021-12-12"
+  },
+  {
+    "name": "Lamar Dodson",
+    "id": 199,
+    "registeredOn": "2022-11-29"
+  },
+  {
+    "name": "Moana Gutierrez",
+    "id": 200,
+    "registeredOn": "2022-01-02"
+  }
+]

--- a/doc-site/pages/examples/rest/Endpoint/01-basic.tsx
+++ b/doc-site/pages/examples/rest/Endpoint/01-basic.tsx
@@ -1,0 +1,24 @@
+/**
+ * Simple usage with useAsync
+ *
+ * This example uses [prepare](doc:Endpoint#Method-prepare) to return a function
+ * that `useAsync` can call. As `prepare` isn't passed any arguments it will always
+ * return the same function. As such `useAsync` will only call it once even if the
+ * component re-renders.
+ */
+import { Endpoint } from '@prestojs/rest';
+import { useAsync } from '@prestojs/util';
+import React from 'react';
+
+const endpoint = new Endpoint<{ id: number; name: string }[]>('/api/users/');
+
+export default function Basic() {
+    const { result } = useAsync(endpoint.prepare(), { trigger: 'SHALLOW' });
+    return (
+        <div>
+            {result?.result.map(user => (
+                <div key={user.id}>{user.name}</div>
+            ))}
+        </div>
+    );
+}

--- a/doc-site/pages/examples/rest/Endpoint/02-query-params.tsx
+++ b/doc-site/pages/examples/rest/Endpoint/02-query-params.tsx
@@ -1,0 +1,36 @@
+/**
+ * Passing query parameters with useAsync
+ *
+ * This example shows what happens when arguments are passed to `prepare`.
+ * When the `query` argument changes `prepare` will return a new function
+ * which `useAsync` will call.
+ */
+import { Endpoint } from '@prestojs/rest';
+import { useAsync } from '@prestojs/util';
+import { Input } from 'antd';
+import 'antd/es/input/style/index.css';
+import React from 'react';
+
+const endpoint = new Endpoint<{ id: number; name: string }[]>('/api/users');
+
+export default function QueryParamsExample() {
+    const [filter, setFilter] = React.useState('');
+    const { result, isLoading } = useAsync(endpoint.prepare({ query: { filter } }), {
+        trigger: 'SHALLOW',
+    });
+    return (
+        <div>
+            <Input
+                disabled={isLoading}
+                type="search"
+                placeholder="Search"
+                // @ts-ignore
+                onPressEnter={({ target: { value } }) => setFilter(value)}
+                style={{ maxWidth: 300 }}
+            />
+            {result?.result.map(user => (
+                <div key={user.id}>{user.name}</div>
+            ))}
+        </div>
+    );
+}

--- a/doc-site/pages/examples/rest/Endpoint/03-pagination.tsx
+++ b/doc-site/pages/examples/rest/Endpoint/03-pagination.tsx
@@ -1,0 +1,56 @@
+/**
+ * Integrating pagination
+ *
+ * This example uses [paginationMiddleware](doc:paginationMiddleware) to handle paginated responses
+ * and [usePaginator](doc:usePaginator) to create a paginator to use with endpoint.
+ * When the `pagination` or `query` arguments to `endpoint.prepare` changes `prepare` will return a
+ * new function which `useAsync` will call.
+ */
+import { Endpoint, paginationMiddleware } from '@prestojs/rest';
+import { PageNumberPaginator, useAsync, usePaginator } from '@prestojs/util';
+import { Input, Pagination } from 'antd';
+import 'antd/dist/antd.css';
+import React from 'react';
+
+const endpoint = new Endpoint<{ id: number; name: string }[]>('/api/paginated-users', {
+    middleware: [paginationMiddleware()],
+});
+
+export default function PaginationExample() {
+    const [filter, setFilter] = React.useState('');
+    const paginator = usePaginator(endpoint) as PageNumberPaginator;
+    const { result, isLoading } = useAsync(endpoint.prepare({ query: { filter }, paginator }), {
+        trigger: 'SHALLOW',
+    });
+    const onSearch = ({ target: { value } }) => {
+        // When filter changes the paginator should reset to page 1 as it's
+        // a new dataset
+        paginator.setPage(1);
+        setFilter(value);
+    };
+    return (
+        <div>
+            <Input
+                disabled={isLoading}
+                type="search"
+                placeholder="Search"
+                // @ts-ignore
+                onPressEnter={onSearch}
+                onBlur={onSearch}
+                style={{ maxWidth: 300 }}
+            />
+            {result?.result.map(user => (
+                <div key={user.id}>{user.name}</div>
+            ))}
+            <Pagination
+                current={paginator.page || 1}
+                pageSize={paginator.pageSize || 10}
+                onChange={(page, pageSize) => {
+                    paginator.setPage(page);
+                    paginator.setPageSize(pageSize);
+                }}
+                total={paginator.total || 0}
+            />
+        </div>
+    );
+}

--- a/doc-site/styles/globals.css
+++ b/doc-site/styles/globals.css
@@ -51,6 +51,9 @@ html {
 .mdx hr {
    @apply my-10;
 }
+.mdx ol {
+   @apply ml-5 my-5;
+}
 
 .DocSearch-Button {
    @apply bg-gray-200 float-right;

--- a/js-packages/@prestojs/doc/src/components/Description.tsx
+++ b/js-packages/@prestojs/doc/src/components/Description.tsx
@@ -3,11 +3,12 @@ import { Flags, RichDescription } from '../newTypes';
 import PrecompiledMarkdown from './PrecompiledMarkdown';
 
 type Props = {
+    shortOnly?: boolean;
     description?: RichDescription;
     flags?: Flags;
 };
 
-export default function Description({ description, flags }: Props) {
+export default function Description({ description, flags, shortOnly }: Props) {
     if (!flags?.isDeprecated && (!description || (!description.short && !description.long))) {
         return null;
     }
@@ -15,7 +16,7 @@ export default function Description({ description, flags }: Props) {
     return (
         <>
             {description?.short && <PrecompiledMarkdown code={description.short} />}
-            {description?.long && <PrecompiledMarkdown code={description.long} />}
+            {description?.long && !shortOnly && <PrecompiledMarkdown code={description.long} />}
             {flags?.isDeprecated && (
                 <div className="text-red-400 flex">
                     <strong className="mr-1">Deprecated{flags.deprecatedReason ? ': ' : ''}</strong>

--- a/js-packages/@prestojs/doc/src/components/FunctionDocumentation.tsx
+++ b/js-packages/@prestojs/doc/src/components/FunctionDocumentation.tsx
@@ -13,6 +13,7 @@ type Props = {
     excludeParameterNames?: string[];
     hideTypeParameters?: boolean;
     hideReturnType?: boolean;
+    hideParameters?: boolean;
     prologue?: React.ReactNode;
 };
 
@@ -21,6 +22,7 @@ export default function FunctionDocumentation({
     excludeParameterNames = [],
     hideTypeParameters,
     hideReturnType,
+    hideParameters,
     prologue,
 }: Props) {
     const parameters = signature.parameters.filter(
@@ -42,11 +44,11 @@ export default function FunctionDocumentation({
             </div>
             <Description description={signature.description} />
             {prologue}
-            {parameters.length > 0 && (
+            {!hideParameters && parameters.length > 0 && (
                 <div className="my-5 overflow-x-auto">
                     <AnchorLink
                         className="font-bold"
-                        component="h2"
+                        component="h3"
                         id={`${signature.anchorId}-props`}
                     >
                         {signature.isComponent ? 'Component Props' : 'Arguments'}:

--- a/js-packages/@prestojs/doc/src/components/OnThisPage.module.css
+++ b/js-packages/@prestojs/doc/src/components/OnThisPage.module.css
@@ -4,6 +4,6 @@
 .activeSection > a {
    @apply border-b border-cyan-500;
 }
-.section ul > li.activeMenu {
+.section ul > li.activeMenu > a {
     @apply bg-gray-100;
 }

--- a/js-packages/@prestojs/doc/src/components/OnThisPage.tsx
+++ b/js-packages/@prestojs/doc/src/components/OnThisPage.tsx
@@ -1,8 +1,53 @@
+import cx from 'classnames';
 import debounce from 'lodash/debounce';
 import React, { useEffect, useMemo, useRef } from 'react';
-import { PageSection } from '../newTypes';
+import { PageSection, PageSectionLink } from '../newTypes';
 import styles from './OnThisPage.module.css';
 import { usePreferences } from './PreferencesProvider';
+
+function OnThisPageLinks({ links, level }: { links: PageSectionLink[]; level: number }) {
+    if (links.length === 0) {
+        return null;
+    }
+    return (
+        <ul>
+            {links.map(({ title, anchorId, links }, i) => (
+                <li
+                    className={cx('block py-1 font-medium hover:text-gray-900', {
+                        'py-0': level > 1,
+                    })}
+                    key={i}
+                >
+                    <a
+                        href={`#${anchorId}`}
+                        className={cx('block', {
+                            'ml-5 pl-2': level > 1,
+                            'mb-2': links.length > 0,
+                            'border-l-2 border-gray-200': level > 1,
+                        })}
+                    >
+                        {level === 1 && (
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4 inline text-gray-400"
+                                viewBox="0 0 20 20"
+                                fill="currentColor"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                    clipRule="evenodd"
+                                />
+                            </svg>
+                        )}{' '}
+                        {title}
+                    </a>
+                    <OnThisPageLinks links={links} level={level + 1} />
+                </li>
+            ))}
+        </ul>
+    );
+}
 
 export function OnThisPageSection({ section }: { section: PageSection }) {
     const { showInherited } = usePreferences();
@@ -11,29 +56,7 @@ export function OnThisPageSection({ section }: { section: PageSection }) {
         <>
             <li className={styles.section}>
                 <a href={`#${section.anchorId}`}>{section.title}</a>
-                {filteredLinks.length > 0 && (
-                    <ul>
-                        {filteredLinks.map(({ title, anchorId }, i) => (
-                            <li className="block py-1 font-medium hover:text-gray-900" key={i}>
-                                <a href={`#${anchorId}`}>
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        className="h-4 w-4 inline text-gray-400"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                                            clipRule="evenodd"
-                                        />
-                                    </svg>{' '}
-                                    {title}
-                                </a>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                <OnThisPageLinks links={filteredLinks} level={1} />
             </li>
         </>
     );

--- a/js-packages/@prestojs/doc/src/components/PrecompiledMarkdown.tsx
+++ b/js-packages/@prestojs/doc/src/components/PrecompiledMarkdown.tsx
@@ -144,6 +144,12 @@ export const mdxComponents = {
         }
         return <Heading component="h3">{props.children}</Heading>;
     },
+    h4: props => {
+        if (typeof props.children != 'string') {
+            return <h3 {...props} />;
+        }
+        return <Heading component="h4">{props.children}</Heading>;
+    },
     blockquote: Alert,
     Alert,
     Usage,

--- a/js-packages/@prestojs/doc/src/components/Type.tsx
+++ b/js-packages/@prestojs/doc/src/components/Type.tsx
@@ -60,7 +60,9 @@ function FunctionDescription({ signatures }: { signatures }) {
                 Function
             </button>
             <Modal isVisible={showModal} onClose={() => setShowModal(false)}>
-                <FunctionDocumentation signature={signatures[0]} />
+                {signatures.map((sig, i) => (
+                    <FunctionDocumentation key={i} signature={sig} />
+                ))}
             </Modal>
         </span>
     );
@@ -70,7 +72,6 @@ export default function Type({ type, mode = 'FULL' }: Props) {
     if (type.typeName === 'container') {
         let el;
         if (type.children.length === 0 && type.indexSignature) {
-            console.log(type.indexSignature);
             el = (
                 <span>
                     <span className="text-gray-400">
@@ -81,6 +82,20 @@ export default function Type({ type, mode = 'FULL' }: Props) {
                         {' }'}
                     </span>
                 </span>
+            );
+        } else if (type.signatures?.length) {
+            el = (
+                <div>
+                    <strong>A function with the following signature:</strong>
+                    <div className="border-l pl-5 my-5">
+                        <FunctionDocumentation signature={type.signatures[0]} />
+                    </div>
+                    <TypeTable
+                        dataSource={type.children}
+                        title={<p>In addition the function has these properties attached to it:</p>}
+                        indexSignature={type.indexSignature}
+                    />
+                </div>
             );
         } else {
             el = (

--- a/js-packages/@prestojs/doc/src/components/TypeTable.tsx
+++ b/js-packages/@prestojs/doc/src/components/TypeTable.tsx
@@ -168,6 +168,7 @@ export default function TypeTable({
                             <Description
                                 description={property.description}
                                 flags={property.flags}
+                                shortOnly={property.type.typeName === 'referenceLink'}
                             />
                         );
                     },

--- a/js-packages/@prestojs/doc/src/index.ts
+++ b/js-packages/@prestojs/doc/src/index.ts
@@ -23,6 +23,7 @@ export type {
     MethodType,
     Page,
     PageSection,
+    PageSectionLink,
     ReferenceLinkType,
     RichDescription,
     Signature,

--- a/js-packages/@prestojs/doc/src/newTypes.ts
+++ b/js-packages/@prestojs/doc/src/newTypes.ts
@@ -13,17 +13,25 @@ export interface FunctionPage {
     typeParameters?: TypeParameter[];
     pageSections: PageSection[];
     isTypeOnly: boolean;
+    hideApi: boolean;
 }
 
 export interface ClassConstructor {
     signatures: Signature[];
 }
 
+export interface PageSectionLink {
+    title: string;
+    anchorId: string;
+    isInherited?: boolean;
+    links: PageSectionLink[];
+}
+
 export interface PageSection {
     title: string;
     anchorId: string;
     showEmpty?: boolean;
-    links: { title: string; anchorId: string; isInherited?: boolean }[];
+    links: PageSectionLink[];
 }
 
 export interface ClassPage {
@@ -160,6 +168,7 @@ export interface ContainerType {
         description?: RichDescription;
     }[];
     indexSignature?: IndexSignatureType;
+    signatures?: Signature[];
 }
 
 export interface UnknownType {

--- a/js-packages/@prestojs/doc/src/pages/ClassPageDoc.tsx
+++ b/js-packages/@prestojs/doc/src/pages/ClassPageDoc.tsx
@@ -103,7 +103,7 @@ function ClassHierarchy({ page }: { page: ClassPage }) {
 
 export default function ClassPageDoc({ page, meta, isNested = false }: Props) {
     const { showInherited } = usePreferences();
-    const showOnThisPage = page.pageSections.length > 0;
+    const showOnThisPage = page.pageSections.length > 0 && !isNested;
     const filterInherited = node => showInherited || !node.isInherited;
     const filterInheritedMethod = node => showInherited || !node.signatures?.[0]?.isInherited;
     const properties = page.properties.filter(filterInherited);

--- a/js-packages/@prestojs/doc/src/pages/FunctionPageDoc.tsx
+++ b/js-packages/@prestojs/doc/src/pages/FunctionPageDoc.tsx
@@ -18,7 +18,12 @@ export default function FunctionPageDoc({ page, meta }: Props) {
             <div className={showOnThisPage ? 'xl:mr-[19.5rem]' : ''}>
                 <PageHeader page={page} meta={meta} />
                 {page.signatures.map((sig, i) => (
-                    <FunctionDocumentation key={i} signature={sig} />
+                    <FunctionDocumentation
+                        key={i}
+                        signature={sig}
+                        hideParameters={page.hideApi}
+                        hideReturnType={page.hideApi}
+                    />
                 ))}
                 {meta.examples && <CodeExamples examples={meta.examples} />}
             </div>

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -809,7 +809,7 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  *    page size and total number of records) and return the `results` to the next middleware in the chain.
  * 4) `execute` will finish processing the remaining middleware and return `result`; from the example above that would
  *    be `[{ id: 1, name: 'Jo' }]`
- * 5) The `paginator` state will reflect what was returned: `paginator.pageSize === 10` and `paginator.total === 1
+ * 5) The `paginator` state will reflect what was returned: `paginator.pageSize === 10` and `paginator.total === 1`
  *
  * To make it easy to instantiate and have a React component re-render when pagination state changes use the
  * [usePaginator](doc:usePaginator) hook. This can accept either a paginator class or the endpoint itself. For example:

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -1,12 +1,16 @@
+import type { UrlPatternResolveOptions } from '@prestojs/routing';
 import { UrlPattern } from '@prestojs/routing';
-import { PaginatorInterface } from '@prestojs/util';
+import { PaginatorInterface, PaginatorInterfaceClass } from '@prestojs/util';
 import isEqual from 'lodash/isEqual';
 import requestDefaultsMiddleware from './requestDefaultsMiddleware';
 
+/**
+ * @export-in-docs
+ */
 type ExecuteInitOptions = Omit<RequestInit, 'headers'> & {
     /**
      * Any headers to add to the request. You can unset default headers that might be specified in the default
-     * `Endpoint.defaultConfig.requestInit` by setting the value to `undefined`.
+     * [Endpoint.defaultConfig.requestInit](#Property-defaultConfig) by setting the value to `undefined`.
      */
     headers?: HeadersInit | Record<string, undefined | string>;
     /**
@@ -27,7 +31,7 @@ export type EndpointRequestInit = { headers: Headers; method: string } & Omit<
     'headers' | 'method'
 >;
 
-interface Query {
+interface QueryStringParams {
     [key: string]: any;
 }
 
@@ -36,10 +40,19 @@ interface Query {
  */
 export type EndpointOptions<ReturnT> = ExecuteInitOptions & {
     /**
-     * Method to decode body based on response. The default implementation looks at the content type of the
-     * response and processes it accordingly (eg. handles JSON and text responses) and is suitable for most cases.
-     * If you just need to transform the decoded body (eg. change the decoded JSON object) then use `middleware`
-     * instead.
+     * Method used to decode the response body.
+     *
+     * The default implementation works as follows:
+     *
+     * 1) If the response code is `204` or `205` it will return null
+     * 2) If type includes 'json' (eg. application/json) returns [response.json()](https://developer.mozilla.org/en-US/docs/Web/API/Response/json)
+     * 3) If type includes 'text' (eg. text/plain, text/html) returns [response.text()](https://developer.mozilla.org/en-US/docs/Web/API/Response/text)
+     * 4) Otherwise returns response unchanged
+     *
+     * If you just need to transform the decoded body (e.g. change the decoded JSON object) then either use `middleware`
+     * or transform the `result` value returned from `execute`.
+     *
+     * @param res The [response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object returned by fetch.
      */
     decodeBody?: (res: Response) => any;
     /**
@@ -51,40 +64,65 @@ export type EndpointOptions<ReturnT> = ExecuteInitOptions & {
      * If not provided defaults to:
      *
      * ```js
-     * function defaultResolveUrl(urlPattern, urlArgs, query, baseUrl) {
-     *      if (baseUrl[baseUrl.length - 1] === '/') {
-     *          baseUrl = baseUrl.slice(0, -1);
-     *      }
-     *      return baseUrl + this.urlPattern.resolve(urlArgs, { query });
-     *  }
+     * function defaultResolveUrl(
+     *     urlPattern: UrlPattern,
+     *     urlArgs: Record<string, any>,
+     *     query: Query | undefined,
+     *     baseUrl: string
+     * ): string {
+     *     if (baseUrl[baseUrl.length - 1] === '/') {
+     *         baseUrl = baseUrl.slice(0, -1);
+     *     }
+     *     const finalOptions: UrlPatternResolveOptions = {};
+     *     if (query) {
+     *         finalOptions.query = query;
+     *     }
+     *     if (!this.urlPattern.resolveOptions.baseUrl) {
+     *         finalOptions.baseUrl = baseUrl;
+     *     }
+     *     return this.urlPattern.resolve(urlArgs, finalOptions);
+     * }
      * ```
+     *
+     * @param urlPattern The url pattern from the endpoint
+     * @param urlArgs The `urlArgs` passed to `execute`
+     * @param query The `query` passed to `execute`
+     * @param baseUrl The `baseUrl` which was passed to `Endpoint` or [Endpoint.defaultConfig.baseUrl](doc:Endpoint#Property-defaultConfig)
+     * if not provided. Note that middleware can also modify this.
      */
     resolveUrl?: (
         urlPattern: UrlPattern,
         urlArgs: Record<string, any>,
-        query: Query | undefined,
+        query: QueryStringParams | undefined,
         baseUrl: string
     ) => string;
     /**
      * Base URL to use. This is prepended to the return value of `urlPattern.resolve(...)` and can be used
      * to change the call to occur to a different domain.
      *
-     * If not specified defaults to [Endpoint.defaultConfig.baseUrl](doc:Endpoint#static-var-defaultConfig)
+     * If not specified defaults to [Endpoint.defaultConfig.baseUrl](doc:Endpoint#Property-defaultConfig)
+     *
+     * <Alert>NOTE: If `urlPattern` defines a `baseUrl` that will always be used regardless of this setting.</Alert>
      */
     baseUrl?: string;
     /**
      * Middleware to apply for this endpoint. By default `getMiddleware` concatenates this with the global
-     * [Endpoint.defaultConfig.middleware](doc:Endpoint#static-var-defaultConfig)
+     * [Endpoint.defaultConfig.middleware](doc:Endpoint#Property-defaultConfig)
      *
      * See [middleware](#Middleware) for more details
      */
     middleware?: Middleware<ReturnT>[];
     /**
-     * Get the final middleware to apply for this endpoint. This combines the global middleware and the middleware
-     * specific to this endpoint. Defaults to [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#static-var-defaultConfig)
+     * Get the final middleware to apply for this endpoint. This should combine the global middleware and the middleware
+     * specific to this endpoint.
+     *
+     * Defaults to [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#Property-defaultConfig)
      * which applies the global middleware followed by the endpoint specific middleware.
      *
      * See [middleware](#Middleware) for more details
+     *
+     * @param middleware The middleware that was passed to the `endpoint`
+     * @param endpoint The endpoint the middleware is being created for.
      */
     getMiddleware?: (
         middleware: Middleware<ReturnT>[],
@@ -92,10 +130,19 @@ export type EndpointOptions<ReturnT> = ExecuteInitOptions & {
     ) => MiddlewareFunction<ReturnT>[];
 };
 
-type UrlResolveOptions = {
+/**
+ * @export-in-docs
+ */
+interface UrlResolveOptions {
+    /**
+     * Any arguments to be passed through to [UrlPattern.resolve](doc:UrlPattern#resolve)
+     */
     urlArgs?: Record<string, any>;
-    query?: Query;
-};
+    /**
+     * Optional query string parameters to be passed through to [UrlPattern.resolve](doc:UrlPattern#resolve)
+     */
+    query?: QueryStringParams;
+}
 
 /**
  * @expand-properties
@@ -112,7 +159,7 @@ export type ExecuteReturnVal<T> = {
     /**
      * Any query string parameters
      */
-    query: Query;
+    query: QueryStringParams;
     /**
      * The options used to execute the endpoint with
      */
@@ -204,7 +251,7 @@ export class MiddlewareContext<T> {
     /**
      * The state as of when the last middleware in the chain was processed.
      *
-     * This contains the `url`, `response`, `decodedBody` and `result`.
+     * This object contains `url`, `response`, `decodedBody` and `result`.
      */
     lastState: null | MiddlewareNextReturn<T>;
 
@@ -300,47 +347,85 @@ export type MiddlewareNextReturn<ReturnT> = {
 export type MiddlewareReturn<ReturnT> = Promise<ReturnT | MiddlewareNextReturn<ReturnT>>;
 
 export type MiddlewareUrlConfig = {
+    /**
+     * The URL pattern passed to the endpoint
+     */
     pattern: UrlPattern;
+    /**
+     * Any arguments that will be passed to [UrlPattern.resolve](doc:UrlPattern#Method-resolve)
+     */
     args: Record<string, any>;
-    query: Query;
+    /**
+     * Any query string arguments that will be added to the URL
+     */
+    query: QueryStringParams;
+    /**
+     * The base URL that will be prepended to the URL returned by [UrlPattern.resolve](doc:UrlPattern#Method-resolve)
+     */
     baseUrl: string;
 };
 
 /**
+ * Middleware process function
+ *
  * @param next The next function in the middleware chain. Must be passed the `url` and `requestInit` objects. Alternatively
  * you can pass an instance of [SkipToResponse](doc:SkipToResponse) instead of `url` and `requestInit`.
  * @param urlConfig The URL config
  * @param requestInit See [fetch parameters](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
  * @param context The context for the current execute. This gives you access to the original options and a function to re-execute the command.
  * @returns Returns the value from `fetch` after it has been transformed by each middleware further down the chain
+ *
+ * @extract-docs
  */
-export type MiddlewareFunction<T> = (
-    next: MiddlewareNextFunction<T>,
-    urlConfig: MiddlewareUrlConfig,
-    requestInit: EndpointRequestInit,
-    context: MiddlewareContext<T>
-) => MiddlewareReturn<T>;
+export interface MiddlewareFunction<T> {
+    (
+        next: MiddlewareNextFunction<T>,
+        urlConfig: MiddlewareUrlConfig,
+        requestInit: EndpointRequestInit,
+        context: MiddlewareContext<T>
+    ): MiddlewareReturn<T>;
+}
 
-type MiddlewareNextFunction<T> = {
+/**
+ * @extract-docs
+ */
+interface MiddlewareNextFunction<T> {
+    /**
+     * Middleware functions should call this to allow processing to continue to the next middleware in the chain. Must
+     * be passed the `url` and `requestInit` objects. Alternatively you can pass an instance of [SkipToResponse](doc:SkipToResponse)
+     * (shown below)
+     * @param urlConfig The URL config that may have been modified by the middleware
+     * @param requestInit The request init object that may have been modified by the middleware
+     */
     (urlConfig: MiddlewareUrlConfig, requestInit: RequestInit): Promise<MiddlewareNextReturn<T>>;
+
+    /**
+     * Alternate way to call `next` is to pass an instance of [SkipToResponse](doc:SkipToResponse)
+     * @param skipToResponse Passing this indicates the middleware should skip to the response bypassing any subsequent
+     * middleware in the chain
+     */
     (skipToResponse: SkipToResponse): Promise<MiddlewareNextReturn<T>>;
-};
+}
 
 /**
  * Object form of middleware. This allows more control over what the middleware can do. Specifically allows middleware
  * to define how it interacts with `Endpoint.prepare` and allows modifications to the `Endpoint` via `init`.
- *
- * @param prepare Function that is called in `Endpoint.prepare` to modify the options used. Specifically this allows middleware
- * to apply it's changes to the options used (eg. change URL etc) such that `Endpoint` correctly caches the call.
- * @param process Process the request through the middleware
- * @param init Called when the `Endpoint` is initialised and allows the middleware to modify the endpoint
- * class or otherwise do some kind of initialisation.
- *
- * @export-in-docs
  */
 export interface MiddlewareObject<T> {
+    /**
+     * Function that is called in `Endpoint.prepare` to modify the options used. Specifically this allows middleware
+     * to apply its changes to the options used (eg. change URL etc) such that `Endpoint` correctly caches the call.
+     */
     prepare?: (options: EndpointExecuteOptions) => EndpointExecuteOptions;
+    /**
+     * Process the request through the middleware
+     */
     process?: MiddlewareFunction<T>;
+    /**
+     * Called when the `Endpoint` is initialised and allows the middleware to modify the endpoint
+     * class or otherwise do some kind of initialisation.
+     * @param endpoint The endpoint that this middleware is attached to
+     */
     init?: (endpoint: Endpoint) => void;
 }
 
@@ -579,7 +664,7 @@ export function defaultDecodeBody(
 function defaultResolveUrl(
     urlPattern: UrlPattern,
     urlArgs: Record<string, any>,
-    query: Query | undefined,
+    query: QueryStringParams | undefined,
     baseUrl: string
 ): string {
     if (baseUrl[baseUrl.length - 1] === '/') {
@@ -610,38 +695,44 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
 }
 
 /**
- * Describe an REST API endpoint that can then be executed.
+ * `Endpoint` is a class that wraps a call to [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
+ * and provides a middleware API to handling transforming the request (e.g. setting headers, adding query params) or
+ * transforming the response (e.g. decoding the body, caching results).
  *
- * * Accepts a [UrlPattern](doc:UrlPattern) to define the URL used. Any arguments & query parameters can be passed at execution time
- * * Accepts a `decodeBody` function that decodes the `Response` body as returned from [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). The
- *   default `decodeBody` will interpret the response based on the content type
- *   * If type includes 'json' (eg. application/json) returns decoded json
- *   * If type includes 'text (eg. text/plain, text/html) returns text
- *   * If status is 204 or 205 will return null
- * * [middleware](#Middleware) can be passed to transform the request before it is passed to `fetch` and/or the response after
- *   it has passed through `decodeBody`.
- * * All options accepted by `fetch` and these will be used as defaults to any call to `execute` or `prepare`.
+ * Global configuration can be set on [Endpoint.defaultConfig](#Property-defaultConfig) to apply site wide settings such as the base URL to use
+ * or default middleware to apply.
  *
- * Usage:
+ * <Usage>
+ *
+ * The most basic usage is to instantiate the class with the URL pattern to use:
  *
  * ```js
- * const userList = new Action(new UrlPattern('/api/users/'));
- * const users = await userList.execute();
+ * const userList = new Endpoint('/api/users/');
+ * // Equivalent to
+ * const userList = new Endpoint(new UrlPattern('/api/users/'));
+ * ```
+ *
+ * See [UrlPattern](doc:UrlPattern) for more details on the pattern syntax.
+ *
+ * To make the call use `execute`:
+ *
+ * ```js
+ * const { result } = await userList.execute();
  * ```
  *
  * You can pass `urlArgs` and `query` to resolve the URL:
  *
  * ```js
- * const userDetail = new Action(new UrlPattern('/api/user/:id/'));
+ * const userDetail = new Endpoint('/api/user/:id/');
  * // Resolves to /api/user/1/?showAddresses=true
- * const user = await userDetail.execute({ urlArgs: { id: 1 }, query: { 'showAddresses': true }});
+ * const { result } = await userDetail.execute({ urlArgs: { id: 1 }, query: { 'showAddresses': true }});
  * ```
  *
  * You can also pass through any `fetch` options to both the constructor and calls to `execute` and `prepare`
  *
  * ```js
  * // Always pass through Content-Type header to all calls to userDetail
- * const userDetail = new Action(new UrlPattern('/api/user/:id/'), {
+ * const userDetail = new Endpoint('/api/user/:id/', {
  *     'Content-Type': 'application/json'
  * });
  * // Set other fetch options at execution time
@@ -658,127 +749,224 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  *     'X-CSRFToken': getCsrfToken(),
  *   },
  * };
- *
- * // All actions will now use the default headers specified
- * userDetail.execute({ urlArgs: { id: 1 } });
  * ```
  *
- * You can also "prepare" an action for execution by calling the `prepare` method. Each call to prepare will
- * return the same object (ie. it passes strict equality checks) given the same parameters. This is useful when
- * you need to have a stable cache key for an action. For example you may have a React hook that executes
- * your action when things change:
+ * ### Prepared endpoints
+ *
+ * You can also "prepare" an endpoint for execution by calling the `prepare` method. Each call to prepare will
+ * return the same object given the same parameters. This is useful when you need to have a stable cache key for an
+ * endpoint. For example, [useAsync](doc:useAsync) can handle calling your function for you while handling loading, error
+ * and success states:
  *
  * ```js
- * import useSWR from 'swr';
+ * const endpoint = new Endpoint('/api/users/');
  *
- * // ...
- *
- * // prepare the action and pass it to useSWR. useSWR will then call the second parameter (the "fetcher")
- * // which executes the prepared action.
- * const { data } = useSWR([action.prepare()], (preparedAction) => preparedAction.execute());
- * ```
- *
- * You can wrap this up in a custom hook to make usage more ergonomic:
- *
- * ```js
- * import { useCallback } from 'react';
- * import useSWR from 'swr';
- *
- * // Wrapper around useSWR for use with `Endpoint`
- * // @param action Endpoint to execute. Can be null if not yet ready to execute
- * // @param args Any args to pass through to `prepare`
- * // @return Object Same values as returned by useSWR with the addition of `execute` which
- * // can be used to execute the action directly, optionally with new arguments.
- * export default function useEndpoint(action, args) {
- *   const preparedAction = action ? action.prepare(args) : null;
- *   const execute = useCallback(init => preparedAction.execute(init), [preparedAction]);
- *   return {
- *     execute,
- *     ...useSWR(preparedAction && [preparedAction], act => act.execute()),
- *   };
+ * export default function Basic() {
+ *     const { result } = useAsync(endpoint.prepare(), { trigger: 'SHALLOW' });
+ *     return (
+ *         <div>
+ *             {result?.result.map(user => (
+ *                 <div key={user.id}>{user.name}</div>
+ *             ))}
+ *         </div>
+ *     );
  * }
  * ```
  *
- * ## Pagination
+ * If the endpoint needed to be re-executed whenever a filter changed you could do this:
  *
- * Pagination for an endpoint is handled by [paginationMiddleware](doc:paginationMiddleware). This middleware
- * will add a `getPaginatorClass` method to the `Endpoint` which makes it compatible with [usePaginator](doc:usePaginator).
- * The default implementation chooses a paginator based on the shape of the response (eg. if the response looks like
- * cursor based paginator it will use `CursorPaginator`, if page number based `PageNumberPaginator` or if limit/offset
- * use `LimitOffsetPaginator` - see [InferredPaginator](doc:InferredPaginator). The pagination state as returned by the
- * backend is stored on the instance of the paginator:
+ * ```js
+ * const [filter, setFilter] = React.useState('');
+ * const { result, isLoading } = useAsync(endpoint.prepare({ query: { filter } }), {
+ *     trigger: 'SHALLOW',
+ * });
+ * ```
+ *
+ * Whenever `filter` changes `prepare` will return a new object and `useAsync` will detect the change and call the
+ * prepared function.
+ *
+ * ### Pagination
+ *
+ * Pagination for an endpoint is handled by [paginationMiddleware](doc:paginationMiddleware). When this middleware
+ * is added [getPaginatorClass](doc:Endpoint#Method-getPaginatorClass) will return the paginator class specified by the
+ * middleware.
+ *
+ * The default paginator is [InferredPaginator](doc:InferredPaginator) which chooses a paginator based on the shape of
+ * the response (e.g. if the response looks like cursor based paginator it will use `CursorPaginator`, if page number
+ * based `PageNumberPaginator` or if limit/offset use `LimitOffsetPaginator`). The pagination state as returned by the
+ * backend is stored on the instance of the paginator and the `result` key returned by execute will contain the _current
+ * page_ of results. The other pagination details (e.g. total number of pages) are retrieved from the paginator.
+ *
+ * Paginators work as follows when used with an `Endpoint`:
+ *
+ * 1) The paginator is created with the initial pagination state
+ * 2) The endpoint `execute` is called and [paginationMiddleware](doc:paginationMiddleware) processes the request. This
+ *    adds the necessary pagination headers or query parameters to the request. For example [PageNumberPaginator](doc:PageNumberPaginator)
+ *    will add `page` and `pageSize` (if they are set) to the query parameters (e.g. `?page=1&pageSize=10`).
+ * 3) The request will be made and the response will be processed by the middleware. In the case of [PageNumberPaginator](doc:PageNumberPaginator)
+ *    the response could look like `{ results: [{ id: 1, name: 'Jo' }], total: 1, pageSize: 10 }` (see the individual paginator class
+ *    documentation for the expected response shape). The paginator will update it's internal state (e.g. set the current
+ *    page size and total number of records) and return the `results` to the next middleware in the chain.
+ * 4) `execute` will finish processing the remaining middleware and return `result`; from the example above that would
+ *    be `[{ id: 1, name: 'Jo' }]`
+ * 5) The `paginator` state will reflect what was returned: `paginator.pageSize === 10` and `paginator.total === 1
+ *
+ * To make it easy to instantiate and have a React component re-render when pagination state changes use the
+ * [usePaginator](doc:usePaginator) hook. This can accept either a paginator class or the endpoint itself. For example:
  *
  * ```js
  * const paginator = usePaginator(endpoint);
- * // This returns the page of results
- * const results = await endpoint.execute({ paginator });
- * // This now has the total number of records (eg. if the paginator was PageNumberPaginator)
- * paginator.total
+ * const { result, isLoading } = useAsync(endpoint.prepare({ paginator }), {
+ *   trigger: 'SHALLOW',
+ * });
  * ```
  *
- * You can calculate the next request state by mutating the paginator:
+ * Calling a paginator state transition function would cause the endpoint to be re-executed:
  *
  * ```js
- * paginator.next()
- * // The call to endpoint here will include the modified page request data, eg. ?page=2
- * const results = await endpoint.execute({ paginator });
+ * paginator.next();
  * ```
  *
- * See [usePaginator](doc:usePaginator) for more details about how to use a paginator in React.
+ * This would call `endpoint` with query string of `?page=2&pageSize=10`.
  *
- * If your backend returns data in a different shape or uses headers instead of putting details in the response body
- * you can handle this by a) implementing your own paginator that extends one of the base classes and customising
- * the `getPaginationState` function or b) passing the `getPaginationState` method to [usePaginator](doc:usePaginator).
- * This function can return the data in the shape expected by the paginator.
+ * See [paginationMiddleware](doc:paginationMiddleware) for more details.
  *
- * ## Middleware
+ * ### Middleware
  *
- * Middleware functions can be provided to alter the `url` or fetch options and transform the
- * response in some way.
+ * Middleware functions can be provided to alter the `urlConfig` or other options passed to `fetch`
+ * and transform the response in some way.
  *
- * Middleware can be defined as either an object or as a function that is passed the url, the fetch options, the next
- * middleware function and a context object. The function can then make changes to the `url` or `requestInit` and pass
+ * Middleware can be defined as either an object or as a function that is passed the url config, the fetch options, the next
+ * middleware function and a context object. The function can then make changes to the `urlConfig` or `requestInit` and pass
  * it through to the next middleware function. The call to `next` returns a `Promise` that resolves to the response of
  * the endpoint after it's been processed by any middleware further down the chain. You can return a modified response here.
  *
- * This middleware sets a custom header on a request but does nothing with the response:
+ * #### Middleware function arguments
+ *
+ * Middleware functions are passed the following arguments:
+ *
+ * * `next` - The next function in the middleware chain. Must be passed the `url` and `requestInit` objects. Alternatively
+ * an instance of [SkipToResponse](doc:SkipToResponse) instead of `url` and `requestInit`. This function _must_ be called
+ * by each middleware.
+ * * `urlConfig` - An object containing the URL config. Details of each key on this object are expanded below.
+ * * `urlConfig.pattern` - The [UrlPattern](doc:UrlPattern) that will be resolved to a URL
+ * * `urlConfig.args` - The arguments to pass to `pattern`
+ * * `urlConfig.query` - Any query string parameters to add to the resolved URL
+ * * `urlConfig.baseUrl` - The base URL to prepend to the URL resolved from the `pattern`
+ * * `requestInit` - See [fetch parameters](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+ * * `context` - The [context](doc:MiddlewareContext) for the current execute. This gives you access to the original options and a function to re-execute the command.
+ *
+ * Each middleware can be split into 2 phases - the _request phase_ which happens before calling `next` the _response phase_
+ * which happens after `next` has resolved:
+ *
+ * ```js
+ * function exampleMiddleware(next, urlConfig, requestInit) {
+ *     // Request phase - modify `urlConfig` or `requestInit` here before handing off to `next`
+ *     // NOTE: Make sure you `await` the call to `next` - it returns a Promise
+ *     const { result } = await next(urlConfig, requestInit);
+ *     // Response phase - modify the `result` before returning it
+ *     return result;
+ * }
+ * ```
+ *
+ * #### Middleware lifecycle
+ *
+ * The lifecycle of a call looks like:
+ *
+ * * [Endpoint.execute](#Method-execute) is called. `urlConfig` is constructed from the pattern & baseUrl
+ * passed to the endpoint and the `urlArgs` and `query` passed to `execute`.
+ * * `requestInit` is constructed by combining [Endpoint.defaultConfig.requestInit](#Property-defaultConfig), any
+ * options provided to the `Endpoint` constructor and any options passed to `execute`
+ * * The first middleware in the chain is called and receives `next`, `urlConfig`, `requestInit` and `context`.
+ * * Once the middleware calls `next` the same process is repeated for all middleware until none remains.
+ * * After the final middleware calls `next` the url is resolved by calling [resolveUrl](#api)
+ * * [fetch](#Method-fetch) is called and `notifyFetchStart` is called (see [Advanced](#Advanced))
+ * * Once the fetch promise resolves [decodeBody](#api) is called
+ * * If [response.ok](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) is false then an
+ * [ApiError](doc:ApiError) will be thrown.
+ * * Otherwise, [context.lastState](doc:MiddlewareContext#Property-lastState) will be set and the last middleware in the chain will receive the result
+ * * Each middleware receives the result as returned by the middleware that was after in the chain.
+ * * Once the entire middleware chain has processed the result the final value is returned from `execute`.
+ *
+ * #### Middleware examples
+ *
+ * This first example adds a custom header:
  *
  * ```js
  * function clientHeaderMiddleware(next, urlConfig, requestInit, context) {
  *   requestInit.headers.set('X-ClientId', 'ABC123');
- *   // Return response unmodified
- *   return next(url.toUpperCase(), requestInit)
+ *   // This middleware doesn't need to do anything to the response so return it directly
+ *   return next(urlConfig, requestInit);
  * }
  * ```
  *
- * This middleware just transforms the response - converting it to uppercase.
+ * This middleware just converts the response to uppercase.
  *
  * ```js
  * function upperCaseResponseMiddleware(next, urlConfig, requestInit, context) {
- *   const { result } = await next(url.toUpperCase(), requestInit)
+ *   const { result } = await next(urlConfig, requestInit)
  *   return result.toUpperCase();
  * }
  * ```
  *
  * Note that `next` will return an object containing `url`, `response`, `decodedBody` and `result`.
- * As a convenience you can return this object directly when you do not need to modify the result
- * in any way (the first example above). `result` contains the value returned from any middleware
- * that handled the response before this one or otherwise `decodedBody` for the first middleware.
+ * `result` contains the value returned from the middleware next in the chain (i.e. the one that handled the response
+ * before this one). Otherwise, it will be the value returned from `decodedBody` for the middleware last in the chain
+ * (i.e. the first middleware to handle the response).
+ *
+ * As a convenience you can return the object returned by `next` directly when you do not need to modify the result
+ * (the first example above). If you need to modify the result you can return the modified result as in the second example
+ * above.
  *
  * The [context object](doc:MiddlewareContext) can be used to retrieve the original options from the [Endpoint.execute](doc:Endpoint#method-execute)
  * call and re-execute the command. This is useful for middleware that may replay a request after an initial failure,
- * eg. if user isn't authenticated on initial attempt.
+ * e.g. if user isn't authenticated on initial attempt.
  *
  * ```js
- * // Access the original parameters passed to execute
- * context.executeOptions
- * // Re-execute the endpoint.
- * context.execute()
+ * async function authReplayMiddleware(next, url, requestInit, context) {
+ *     try {
+ *         return await next(url, requestInit);
+ *     } catch (e) {
+ *         if (e.status === 401) {
+ *             auth.setUserData(null);
+ *             // New promise only resolves once successful login occurs
+ *             return new Promise(resolve => {
+ *                 const unsub = auth.onAuthStateChanged(async user => {
+ *                     if (user) {
+ *                     // When user has logged in re-execute endpoint
+ *                         const result = await context.execute();
+ *                         resolve(result);
+ *                         unsub();
+ *                     }
+ *                 });
+ *             });
+ *         }
+ *         throw e;
+ *     }
+ * }
  * ```
  *
- * **NOTE:** Calling `context.execute()` will go through all the middleware again
+ * **NOTE:** Calling `context.execute()` from within middleware will go through all the middleware again
  *
- * Middleware can be set globally for all [Endpoint](doc:Endpoint)'s on the [Endpoint.defaultConfig.middleware](doc:Endpoint#static-var-defaultConfig)
+ * It is also useful just to get access to the endpoint. This middleware adds a header when the [paginationMiddleware](doc:paginationMiddleware)
+ * is present:
+ *
+ * ```js
+ * function detectPaginationMiddleware(next, urlConfig, requestInit, context) {
+ *     const paginationMiddleware = context.endpoint.middleware.find(
+ *         middleware => middleware instanceof PaginationMiddleware
+ *     );
+ *     requestInit.headers.set(
+ *         'X-HANDLES-PAGINATED-RESPONSE',
+ *         paginationMiddleware ? 'True' : 'False'
+ *     );
+ *     return next(urlConfig, requestInit);
+ * }
+ * ```
+ *
+ * #### Middleware configuration
+ *
+ * Middleware can be set globally for all [Endpoint](doc:Endpoint)'s on the [Endpoint.defaultConfig.middleware](doc:Endpoint#Property-defaultConfig)
  * option or individually for each Endpoint by passing the `middleware` as an option when creating the endpoint.
  *
  * Set globally:
@@ -795,8 +983,8 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  * new Endpoint('/users/', { middleware: [csrfTokenMiddleware] })
  * ```
  *
- * When middleware is passed to the `Endpoint` it is _appended_ to the default
- * middleware specified in `Endpoint.defaultConfig.middleware`.
+ * When middleware is passed to the `Endpoint` the default behaviour is to _append_ it to the default
+ * middleware specified in [Endpoint.defaultConfig.middleware](#Property-defaultConfig).
  *
  * To change how middleware is combined per `Endpoint` you can specify the
  * `getMiddleware` option. This is passed the middleware for the `Endpoint` and
@@ -811,17 +999,34 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  * ]
  * ```
  *
- * You can change the default implementation on [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#static-var-defaultConfig)
+ * You can change the default implementation on [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#Property-defaultConfig)
+ *
+ * #### Middleware object form
  *
  * Middleware can also be defined as an object with any of the following properties:
  *
  * * `init` - Called when the `Endpoint` is initialised and allows the middleware to modify the endpoint
  *   class or otherwise do some kind of initialisation.
  * * `prepare` - A function that is called in `Endpoint.prepare` to modify the options used. Specifically this allows middleware
- *   to apply its changes to the options used (eg. change URL etc) such that `Endpoint` correctly caches the call.
+ *   to apply its changes to the options used (e.g. change URL etc.) such that `Endpoint` correctly caches the call.
  * * `process` - Process the middleware. This behaves the same as the function form described above.
  *
- * ### Advanced
+ * Here's an example of middleware that checks that `method` is uppercase:
+ *
+ * ```js
+ * function checkEndpointSettingsMiddleware() {
+ *     return {
+ *         init(endpoint) {
+ *             const { method } = endpoint.requestInit;
+ *             if (method && method.toUpperCase() !== method) {
+ *                 throw new Error(`'method' must be uppercase`);
+ *             }
+ *         },
+ *     };
+ * }
+ * ```
+ *
+ * #### Advanced
  *
  * For advanced use cases there's some additional hooks available.
  *
@@ -829,17 +1034,44 @@ function isEqualPrepareKey(a: ExecuteInitOptions, b: ExecuteInitOptions): boolea
  *   when the call to `fetch` starts and get access to the `Promise`. [dedupeInFlightRequestsMiddleware](doc:dedupeInFlightRequestsMiddleware)
  *   uses this to cache an in flight request and return the same response for duplicate calls using [SkipToResponse](doc:SkipToResponse)
  * * [SkipToResponse](doc:SkipToResponse) - This allows middleware to skip the rest of the middleware chain and the call
- *   to `fetch`. Instead it is passed a promise that resolves to `Response` and this is used instead of doing the call
+ *   to `fetch`. Instead, it is passed a promise that resolves to `Response` and this is used instead of doing the call
  *   to `fetch` for you.
+ *
+ * #### Available Middleware
+ *
+ * * [paginationMiddleware](doc:paginationMiddleware) - handle paginated responses
+ * * [dedupeInFlightRequestsMiddleware](doc:dedupeInFlightRequestsMiddleware) - Middleware that will dedupe simultaneous identical in flight requests
+ * * [detectBadPaginationMiddleware](doc:detectBadPaginationMiddleware) - Middleware that detects if paginationMiddleware isn't present when it should be or if `pagination` option to `Endpoint.execute` hasn't been supplied.
+ * * [batchMiddleware](doc:batchMiddleware) - This can be used to batch together multiple calls to an endpoint (or endpoints) to make it more efficient.
+ * * [requestDefaultsMiddleware](doc:requestDefaultsMiddleware) - Middleware to set defaults on `requestInit` (included by default)
+ * * [viewModelCachingMiddleware](doc:viewModelCachingMiddleware) - Middleware to transform and cache a response for a [view model](/docs/viewmodel)
+ *
+ * </Usage>
+ *
  *
  * @menu-group Endpoint
  * @extract-docs
+ * @typeParam ReturnT The type of the result returned by the endpoint.
  */
 export default class Endpoint<ReturnT = any> {
     /**
      * This defines the default settings to use on an endpoint globally.
      *
      * All these options can be customised on individual Endpoints.
+     *
+     * The default setup is:
+     *
+     * ```js
+     * Endpoint.defaultConfig = {
+     *     baseUrl: '',
+     *     requestInit: {},
+     *     middleware: [requestDefaultsMiddleware],
+     *     getMiddleware: (middleware) => [
+     *         ...Endpoint.defaultConfig.middleware,
+     *         ...middleware,
+     *     ],
+     * };
+     * ```
      */
     // Init for this is after class definition
     static defaultConfig: DefaultConfig;
@@ -848,15 +1080,42 @@ export default class Endpoint<ReturnT = any> {
      * The [UrlPattern](doc:UrlPattern) this endpoint hits when executed.
      */
     urlPattern: UrlPattern;
+    /**
+     * The default options used when executing the endpoint. These can be overridden
+     * by the call to `execute`.
+     */
     public requestInit: ExecuteInitOptions;
-    private urlCache: Map<string, Map<{}, PreparedAction>>;
+    private urlCache: Map<string, Map<{}, PreparedEndpoint<ReturnT>>>;
+    /**
+     * @private
+     */
     public decodeBody: (res: Response) => any;
+
+    /**
+     * Resolves the URL to use.
+     *
+     * @param urlPattern The url pattern from the endpoint
+     * @param urlArgs The `urlArgs` passed to `execute`
+     * @param query The `query` passed to `execute`
+     * @param baseUrl The `baseUrl` which was passed to `Endpoint` or [Endpoint.defaultConfig.baseUrl](doc:Endpoint#Property-defaultConfig)
+     * if not provided. Note that middleware can also modify this.
+     *
+     *
+     * This is set to the `resolveUrl` passed in the constructor
+     *
+     * @private
+     */
     public resolveUrl: (
         urlPattern: UrlPattern,
         urlArgs: Record<string, any>,
-        query: Query | undefined,
+        query: QueryStringParams | undefined,
         baseUrl: string
     ) => string;
+    /**
+     * The middleware specified for this Endpoint. This is set when the `Endpoint` is
+     * constructed by calling `getMiddleware` (default implementation is
+     * [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#Property-defaultConfig))
+     */
     public middleware: Middleware<ReturnT>[];
 
     private _baseUrl?: string;
@@ -864,7 +1123,7 @@ export default class Endpoint<ReturnT = any> {
     /**
      * The base URL to use for this endpoint. This is prepended to the URL returned from `urlPattern.resolve`.
      *
-     * If not specified then it defaults to [Endpoint.defaultConfig.baseUrl](doc:Endpoint#static-var-defaultConfig).
+     * If not specified then it defaults to [Endpoint.defaultConfig.baseUrl](doc:Endpoint#Property-defaultConfig).
      *
      * Note that middleware can override this as well.
      */
@@ -966,7 +1225,7 @@ export default class Endpoint<ReturnT = any> {
     }
 
     /**
-     * Triggers the `fetch` call for an action
+     * Triggers the `fetch` call for an endpoint
      *
      * This can be called directly or indirectly via `prepare`.
      *
@@ -983,12 +1242,15 @@ export default class Endpoint<ReturnT = any> {
      *
      * ```js
      * // Via prepare
-     * const preparedAction = action.prepare({ urlArgs: { id: '1' }});
-     * preparedAction.execute();
+     * const preparedEndpoint = endpoint.prepare({ urlArgs: { id: '1' }});
+     * preparedEndpoint();
      *
      * // Directly
-     * action.execute({ urlArgs: { id: '1' }});
+     * endpoint.execute({ urlArgs: { id: '1' }});
      * ```
+     *
+     * See [middleware lifecycle](#Middleware-lifecycle) for details about the execution lifecycle.
+     *
      *
      * @param options.urlArgs args to pass through to `urlPattern.resolve`
      * @param options.query query params to pass through to `urlPattern.resolve`
@@ -1132,12 +1394,13 @@ export default class Endpoint<ReturnT = any> {
     }
 
     /**
-     * Calls [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+     * Calls [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) with the
+     * arguments provided.
      *
      * You can extend `Endpoint` and override this if you need to customise something that isn't
      * possible with middleware.
      */
-    public async fetch(url: string, requestInit: RequestInit | undefined): Promise<Response> {
+    public async fetch(url: string, requestInit?: RequestInit): Promise<Response> {
         return fetch(url, requestInit);
     }
 

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -1140,6 +1140,15 @@ export default class Endpoint<ReturnT = any> {
     public async fetch(url: string, requestInit: RequestInit | undefined): Promise<Response> {
         return fetch(url, requestInit);
     }
+
+    /**
+     * Not implemented by default. Include [paginationMiddleware](doc:paginationMiddleware) to enable this functionality.
+     */
+    public getPaginatorClass<T extends PaginatorInterface>(): PaginatorInterfaceClass<T> | null {
+        throw new Error(
+            'getPaginatorClass not implemented - did you forget to include `paginationMiddleware`?'
+        );
+    }
 }
 
 // Initialisation is not done inline in class as doc extractor doesn't handle object literals well

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -871,9 +871,11 @@ export default class Endpoint<ReturnT = any> {
     }
 
     /**
-     * @param urlPattern The [UrlPattern](doc:UrlPattern) to use to resolve the URL for this endpoint
+     * @param urlPattern The [UrlPattern](doc:UrlPattern) to use to resolve the URL for this endpoint. If a plain `string`
+     * is passed it will be converted to a [UrlPattern](doc:UrlPattern).
+     * @param options The options to use for this endpoint.
      */
-    constructor(urlPattern: UrlPattern, options: EndpointOptions<ReturnT> = {}) {
+    constructor(urlPattern: UrlPattern | string, options: EndpointOptions<ReturnT> = {}) {
         const {
             decodeBody = defaultDecodeBody,
             resolveUrl = defaultResolveUrl,
@@ -884,7 +886,8 @@ export default class Endpoint<ReturnT = any> {
         } = options;
 
         this._baseUrl = baseUrl;
-        this.urlPattern = urlPattern;
+        this.urlPattern =
+            urlPattern instanceof UrlPattern ? urlPattern : new UrlPattern(urlPattern);
         this.urlCache = new Map();
         this.decodeBody = decodeBody;
         this.requestInit = requestInit;

--- a/js-packages/@prestojs/rest/src/Endpoint.ts
+++ b/js-packages/@prestojs/rest/src/Endpoint.ts
@@ -585,7 +585,14 @@ function defaultResolveUrl(
     if (baseUrl[baseUrl.length - 1] === '/') {
         baseUrl = baseUrl.slice(0, -1);
     }
-    return baseUrl + this.urlPattern.resolve(urlArgs, { query });
+    const finalOptions: UrlPatternResolveOptions = {};
+    if (query) {
+        finalOptions.query = query;
+    }
+    if (!this.urlPattern.resolveOptions.baseUrl) {
+        finalOptions.baseUrl = baseUrl;
+    }
+    return this.urlPattern.resolve(urlArgs, finalOptions);
 }
 
 /**

--- a/js-packages/@prestojs/rest/src/batchMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/batchMiddleware.ts
@@ -300,7 +300,7 @@ class BatchMiddleware<BatchCallReturn, IndividualResult> {
  * > This allows you to have multiple conditional batching middleware for example. All `batchMiddleware` must appear
  * > last in the chain (ie. `batchingMiddleware` can only be proceeded by another `batchMiddleware`).
  *
- * @returns Middleware function to pass to [Endpoint](doc:Endpoint) or set on [Endpoint.defaultConfig.middleware](http://localhost:3000/docs/rest/Endpoint#static-var-defaultConfig)
+ * @returns Middleware function to pass to [Endpoint](doc:Endpoint) or set on [Endpoint.defaultConfig.middleware](doc:Endpoint#Property-defaultConfig)
  * @extract-docs
  * @menu-group Middleware
  * @return-type-name Middleware function

--- a/js-packages/@prestojs/rest/src/dedupeInFlightRequestsMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/dedupeInFlightRequestsMiddleware.ts
@@ -51,7 +51,7 @@ type DedupeOptions = {
 
 /**
  * Middleware that will dedupe simultaneous identical in flight requests. All requests that are matched
- * as duplicates will all resolve to the same value with only a single `fetch` call having occured.
+ * as duplicates will all resolve to the same value with only a single `fetch` call having occurred.
  *
  * To use this globally set the following somewhere that executes when your app starts:
  *
@@ -61,7 +61,7 @@ type DedupeOptions = {
  * ];
  * ```
  *
- * @returns Middleware function to pass to [Endpoint](doc:Endpoint) or set on [Endpoint.defaultConfig.middleware](http://localhost:3000/docs/rest/Endpoint#static-var-defaultConfig)
+ * @returns Middleware function to pass to [Endpoint](doc:Endpoint) or set on [Endpoint.defaultConfig.middleware](doc:Endpoint#Property-defaultConfig)
  * @extract-docs
  * @menu-group Middleware
  */

--- a/js-packages/@prestojs/rest/src/paginationMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/paginationMiddleware.ts
@@ -82,9 +82,11 @@ export class PaginationMiddleware<T> {
         this.resultPath = resultPath;
     }
     init(endpoint: Endpoint): void {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (endpoint.getPaginatorClass) {
+        if (
+            endpoint.getPaginatorClass &&
+            // There's a default implementation that just throws an error - ignore that
+            endpoint.getPaginatorClass !== Endpoint.prototype.getPaginatorClass
+        ) {
             throw new Error(
                 "Endpoint already has 'getPaginatorClass'. This could be because paginationMiddleware is included twice."
             );

--- a/js-packages/@prestojs/rest/src/requestDefaultsMiddleware.ts
+++ b/js-packages/@prestojs/rest/src/requestDefaultsMiddleware.ts
@@ -3,16 +3,40 @@ import { EndpointRequestInit, MiddlewareReturn, MiddlewareUrlConfig } from './En
 /**
  * Middleware to set defaults on `requestInit`.
  *
- * This is a convenience for other middleware so they can assume certain properties
+ * This is a convenience for other middleware so that they can assume certain properties
  * are always set.
  *
  * * If `method` is not set it will set it to `GET`
  * * If `headers` is not set will set it to `new Headers()`
  *
- * This is included by default in [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#static-var-defaultConfig).
+ * This is included by default in [Endpoint.defaultConfig.getMiddleware](doc:Endpoint#Property-defaultConfig).
+ *
+ * <Usage>
+ * This middleware is included by default. If you have customised `defaultConfig` it's recommended you keep this
+ * middleware:
+ *
+ * ```
+ * Endpoint.defaultConfig.middleware = [
+ *    requestDefaultsMiddleware,
+ *    customMiddleware1,
+ *    customMiddleware2,
+ * ]
+ * ```
+ *
+ * Or if you are providing a custom `getMiddleware` that doesn't refer to `defaultConfig.middleware`:
+ *
+ * ```js
+ * Endpoint.defaultConfig.getMiddleware = (middleware) => [
+ *      requestDefaultsMiddleware,
+ *      customGlobalDefaultMiddleware,
+ *     ...middleware,
+ * ],
+ * ```
+ * </Usage>
  *
  * @extract-docs
  * @menu-group Middleware
+ * @hide-api
  */
 export default function requestDefaultsMiddleware<T>(
     next: (urlConfig: MiddlewareUrlConfig, requestInit: RequestInit) => Promise<T>,

--- a/js-packages/@prestojs/routing/src/NamedUrlPatterns.ts
+++ b/js-packages/@prestojs/routing/src/NamedUrlPatterns.ts
@@ -1,4 +1,4 @@
-import UrlPattern, { ResolveOptions } from './UrlPattern';
+import UrlPattern, { UrlPatternResolveOptions } from './UrlPattern';
 
 type UrlPatternMapping = {
     [urlName: string]: UrlPattern;
@@ -91,7 +91,7 @@ export default class NamedUrlPatterns<Patterns extends UrlPatternMapping> {
      * @param options Extra options to pass through to `UrlPattern.resolve`
      * @param-type-name name string
      */
-    reverse(name: keyof Patterns, kwargs: {} = {}, options: ResolveOptions = {}): string {
+    reverse(name: keyof Patterns, kwargs: {} = {}, options: UrlPatternResolveOptions = {}): string {
         const url = this.get(name);
         return url.resolve(kwargs, options);
     }

--- a/js-packages/@prestojs/routing/src/UrlPattern.ts
+++ b/js-packages/@prestojs/routing/src/UrlPattern.ts
@@ -16,7 +16,7 @@ export interface UrlPatternResolveOptions {
      * If `true` (the default) then any query parameters provided to the constructor will be
      * merged with any provided to `resolve`.
      *
-     * ```
+     * ```js
      * const pattern = new UrlPattern('/users/:id/', { query: { token: 'abc123'}});
      * pattern.resolve({ id: '123' });
      * // /users/5/?token=abc123

--- a/js-packages/@prestojs/routing/src/__tests__/UrlPattern.test.ts
+++ b/js-packages/@prestojs/routing/src/__tests__/UrlPattern.test.ts
@@ -7,3 +7,34 @@ test('Url.resolve should validate args', () => {
     expect(urlPattern.resolve({ name: 'bob' })).toBe('/test/bob/');
     expect(urlPattern.resolve({ name: 'bob', id: '5' })).toBe('/test/bob/5/');
 });
+
+test('should support baseUrl', () => {
+    const urlPattern = new UrlPattern('/test/:name/', { baseUrl: 'http://www.examaple.com' });
+    expect(urlPattern.resolve({ name: 'bob' })).toBe('http://www.examaple.com/test/bob/');
+    expect(urlPattern.resolve({ name: 'bob' }, { baseUrl: 'http://somewhere.else/' })).toBe(
+        'http://somewhere.else/test/bob/'
+    );
+    expect(urlPattern.resolve({ name: 'bob' }, { baseUrl: null })).toBe('/test/bob/');
+});
+
+test('should support query', () => {
+    const urlPattern = new UrlPattern('/test/:name/', { query: { a: 1 } });
+    expect(urlPattern.resolve({ name: 'bob' })).toBe('/test/bob/?a=1');
+    expect(urlPattern.resolve({ name: 'bob' }, { query: { b: 2 } })).toBe('/test/bob/?a=1&b=2');
+    expect(urlPattern.resolve({ name: 'bob' }, { query: { b: 2 }, mergeQuery: false })).toBe(
+        '/test/bob/?b=2'
+    );
+    expect(urlPattern.resolve({ name: 'bob' }, { baseUrl: 'http://example.com/' })).toBe(
+        'http://example.com/test/bob/?a=1'
+    );
+    expect(
+        urlPattern.resolve({ name: 'bob' }, { baseUrl: 'http://example.com/', query: { a: 5 } })
+    ).toBe('http://example.com/test/bob/?a=5');
+
+    const urlPattern2 = new UrlPattern('/test/:name/', { query: { a: 1 }, mergeQuery: false });
+    expect(urlPattern2.resolve({ name: 'bob' })).toBe('/test/bob/?a=1');
+    expect(urlPattern2.resolve({ name: 'bob' }, { query: { b: 2 } })).toBe('/test/bob/?b=2');
+    expect(urlPattern2.resolve({ name: 'bob' }, { query: { b: 2 }, mergeQuery: true })).toBe(
+        '/test/bob/?a=1&b=2'
+    );
+});

--- a/js-packages/@prestojs/routing/src/index.ts
+++ b/js-packages/@prestojs/routing/src/index.ts
@@ -1,3 +1,5 @@
 export { default as UrlPattern } from './UrlPattern';
 export { default as NamedUrlPatterns } from './NamedUrlPatterns';
 export { default as useUrlQueryState } from './useUrlQueryState';
+
+export type { UrlPatternResolveOptions } from './UrlPattern';

--- a/js-packages/@prestojs/util/src/pagination/Paginator.ts
+++ b/js-packages/@prestojs/util/src/pagination/Paginator.ts
@@ -70,6 +70,11 @@ export type PaginationRequestDetails = {
 };
 
 /**
+ * The interface a paginator class should conform to.
+ *
+ * See [PageNumberPaginator](doc:PageNumberPaginator), [CursorPaginator](doc:CursorPaginator), [LimitOffsetPaginator](doc:LimitOffsetPaginator),
+ * and [InferredPaginator](doc:InferredPaginator) for concrete implementations.
+ *
  * @typeParam State Type representing the state of the pagination
  * @typeParam InternalState Type representing the internal state of the pagination. Internal state refers to state that does not need to be restored (eg. pagination details from the URL for example)
  */


### PR DESCRIPTION
Easiest to review commit by commit - last commit contains bunch of doc updates

* Add new options to UrlPattern
  - Allow specifying options in constructor
  - Add baseUrl option for configuring base url to use at the pattern level
  - Add mergeQuery option for opting in/out of merging query options if defined at class level
* Endpoint.prepare returns a function not an object anymore. This changes usage from `endpoint.prepare().execute()` to `endpoint.prepare()()` (but the former will still work with a deprecation notice)
  - This makes usage with useAsync much easier, eg. `useAsync(endpoint.prepare(), { trigger: 'SHALLOW' })` will work now
* Accept `string` as well as `UrlPattern` to `Endpoint` (if `string` will create `UrlPattern` from it)
