### PR TITLE
fix: ensure current page is set after response received

### DIFF
--- a/js-packages/@prestojs/util/src/__tests__/PageNumberPaginator.test.ts
+++ b/js-packages/@prestojs/util/src/__tests__/PageNumberPaginator.test.ts
@@ -122,7 +122,7 @@ test('should handle changing page size', () => {
     expect(result.current.pageSizeState(10)).toEqual({ pageSize: 10 });
     expect(result.current.currentState).toEqual({ pageSize: 10 });
     act(() => result.current.setResponse({ total: 20 }));
-    expect(result.current.currentState).toEqual({ pageSize: 10 });
+    expect(result.current.currentState).toEqual({ page: 1, pageSize: 10 });
     act(() => result.current.setPageSize(5));
     expect(result.current.currentState).toEqual({ page: 1, pageSize: 5 });
     act(() => result.current.setPage(2));
@@ -149,6 +149,7 @@ test('should set responseIsSet', () => {
     expect(result.current.responseIsSet).toBe(false);
     act(() => result.current.setResponse({ total: 30, pageSize: 10 }));
     expect(result.current.responseIsSet).toBe(true);
+    expect(result.current.currentState).toEqual({ pageSize: 10, page: 1 });
 });
 
 test('should support hasNextPage', () => {

--- a/js-packages/@prestojs/util/src/pagination/PageNumberPaginator.ts
+++ b/js-packages/@prestojs/util/src/pagination/PageNumberPaginator.ts
@@ -224,6 +224,10 @@ export default class PageNumberPaginator extends Paginator<
      */
     setResponse({ total, pageSize }: { total: number; pageSize?: number }): void {
         this.setInternalState({ total });
+        if (!this.currentState.page) {
+            // If page hasn't been set do so now so `currentState` always contains it after response received.
+            this.setPage(1);
+        }
         if (pageSize && this.currentState.pageSize !== pageSize) {
             this.setPageSize(pageSize);
         }


### PR DESCRIPTION
This resolves a bug with SelectAsyncChoicesWidget which relies on checking if state will change if go back to page 1:

https://github.com/prestojs/prestojs/blob/master/js-packages/%40prestojs/ui-antd/src/widgets/SelectAsyncChoicesWidget.tsx#L345

Without this change this comparison fails due to `{ pageSize: 20 }` (the state after response is set) != `{ page: 1, pageSize: 20 }` (the result of `firstState()`). 