### PR TITLE
Migrate useViewModelCache to use useSyncExternalStoreWithSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* `ViewModelCache` now has a `deleteAll` method to clear the cache
+
+### Changed
+
+* `useViewModelCache` now longer relies on `useLayoutEffect` and so works better with server-side rendering.
+
 ## [0.0.35] - 2023-02-13
 
 ### Added

--- a/js-packages/@prestojs/viewmodel/package.json
+++ b/js-packages/@prestojs/viewmodel/package.json
@@ -32,6 +32,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
+    "use-sync-external-store": "^1.2.0",
     "lodash": "^4.17.15"
   }
 }

--- a/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/ViewModelCache.ts
@@ -1614,4 +1614,28 @@ export default class ViewModelCache<ViewModelClassType extends ViewModelConstruc
             unsubscribes.forEach(cb => cb());
         };
     }
+
+    /**
+     * Deletes all records from the cache, optionally limiting to a subset of fields.
+     *
+     * @param fieldNames Optionally only delete the entries with the specified field names. If
+     * this is not set then all data for every record is removed. See [Field notation](#Field_notation) for supported format.
+     *
+     * **NOTE:** When deleting a subset of fields be aware that if a superset of those fields exist in the
+     * cache then the records with partial fields will be recreated next time they are accessed.
+     */
+    deleteAll(fieldNames?: FieldPaths<ViewModelClassType>) {
+        withEnableListeners(() => {
+            this.batch(() => {
+                for (const pk of this.fieldNameCache.keys()) {
+                    this.acquireFieldNameCache(pk);
+                    const pkKey = this.getPkCacheKey(pk);
+                    const recordCache = this.fieldNameCache.get(pkKey);
+                    if (recordCache) {
+                        recordCache.delete(fieldNames);
+                    }
+                }
+            });
+        });
+    }
 }

--- a/js-packages/@prestojs/viewmodel/src/useViewModelCache.ts
+++ b/js-packages/@prestojs/viewmodel/src/useViewModelCache.ts
@@ -137,7 +137,10 @@ export default function useViewModelCache<
                 selector(cache, ...args),
         [selector, args]
     );
-    const selectedState = useSyncExternalStoreWithSelector(
+    const selectedState = useSyncExternalStoreWithSelector<
+        { cache: ViewModelCache<ViewModelType> },
+        ResultType
+    >(
         useCallback(
             callback => {
                 return viewModel.cache.addListener(() => {

--- a/js-testing/presto-testing-library.tsx
+++ b/js-testing/presto-testing-library.tsx
@@ -21,3 +21,4 @@ export * from '@testing-library/react';
 
 export { customRender as render };
 export { customRenderHook as renderHook };
+export { render as renderNoStrictMode };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react": "^18.2.14",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
+    "@types/use-sync-external-store": "^0.0.6",
     "@yarnpkg/pnpify": "^2.0.0-rc.18",
     "babel-jest": "^26.6.3",
     "commitizen": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18891,6 +18891,11 @@ use-latest@^1.0.0:
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
 
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4938,6 +4938,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/use-sync-external-store@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
+  integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
+
 "@types/webpack-env@^1.16.0":
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.4.tgz#1f4969042bf76d7ef7b5914f59b3b60073f4e1f4"
@@ -18890,11 +18895,6 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
-
-use-sync-external-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
useSyncExternalStoreWithSelector is the official solution for this type of thing (or https://react.dev/reference/react/useSyncExternalStore is, this is a specialised version used in react-redux that seems to be officially supported)

This works better with server side rendering - right now SSR produces many warnings because of the usage of useLayoutEffect (this has no effect on the server). This change gets rid of that and also means data will be available on the server. It worked before anyway because the data is selected outside of useLayoutEffect on initial renders, but this is probably more robust and is more likely to be more compatible with things like concurrent mode going forward.

Also included is adding `deleteAll` to ViewModelCache (tangentially related to issues with SSR in that in AP2 we clear caches in SSR to avoid leaking data between requests)